### PR TITLE
Restrict post reading JS to button within article wrap

### DIFF
--- a/modules/reading/assets/js/post-reading.js
+++ b/modules/reading/assets/js/post-reading.js
@@ -7,8 +7,10 @@
  */
 document.addEventListener("DOMContentLoaded", () => {
   const wrap = document.querySelector(".politeia-post-reading-wrap");
-  const btn  = document.querySelector(".politeia-post-reading-btn");
   if (!wrap || typeof politeiaPostReading === "undefined") return;
+
+  // Limita cualquier manipulación al botón que vive dentro del wrapper del post.
+  const btn = wrap.querySelector(".politeia-post-reading-btn");
 
   /* ---------- Inyectar barra de progreso (sin tocar PHP) ---------- */
   const progress = document.createElement("div");


### PR DESCRIPTION
## Summary
- ensure the post-reading JavaScript only targets the button rendered with the article wrapper so other UI elements stay unchanged

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cded6291e48332850caafe8f75cee2