### PR TITLE
Add remote cover fetching support

### DIFF
--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -147,16 +147,18 @@ span#purchase-channel-form {
 
 	#prs-book-cover{ grid-column:1; grid-row:1 / span 2; padding:0; background:transparent; }
 
-	.prs-cover-frame{
-	position: relative;
-	width: 100%;
-	max-height: 450px; /* desktop */
-	overflow: hidden;
-	border-radius: 10px;
-	background: #eee;
-	}
-	.prs-cover-img{ width:100%; height:100%; object-fit:cover; display:block; }
-	.prs-cover-placeholder{ width:100%; height:100%; min-height:180px; background:#eee; }
+        .prs-cover-frame{
+        position: relative;
+        width: 280px;
+        max-width: 100%;
+        height: auto;
+        overflow: hidden;
+        border-radius: 10px;
+        background: #eee;
+        margin: 0 auto;
+        }
+        .prs-cover-img{ width:100%; height:auto; object-fit:contain; display:block; }
+        .prs-cover-placeholder{ width:100%; aspect-ratio:280 / 450; background:#eee; }
 
 	/* Botón centrado dentro del frame */
         .prs-cover-overlay{
@@ -197,9 +199,8 @@ span#purchase-channel-form {
 	.prs-cover-frame.has-image .prs-cover-overlay{ opacity:0; transition:opacity .2s; }
 	.prs-cover-frame.has-image:hover .prs-cover-overlay{ opacity:1; background:rgba(0,0,0,.25); }
 
-	/* Tablet / Mobile max-heights */
-	@media (min-width:481px) and (max-width:900px){ .prs-cover-frame{ max-height:280px; } }
-	@media (max-width:480px){ .prs-cover-frame{ max-height:220px; } }
+        /* Tablet / Mobile tweaks */
+        @media (max-width:480px){ .prs-cover-frame{ width:220px; } }
 
 	div#prs-book-info {
 	background: white;

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -159,21 +159,39 @@ span#purchase-channel-form {
 	.prs-cover-placeholder{ width:100%; height:100%; min-height:180px; background:#eee; }
 
 	/* Botón centrado dentro del frame */
-	.prs-cover-overlay{
-	position:absolute; inset:0;
-	display:flex; align-items:center; justify-content:center;
-	pointer-events:auto; /* ← así los botones siempre reciben el click */
-	}
-	#prs-cover-upload{
-	pointer-events:auto;
-	padding:10px 14px; border:none; border-radius:10px; cursor:pointer;
-	background:#111; color:#fff; box-shadow:none; outline:none;
-	}
-	#prs-cover-remove{
-	pointer-events:auto;
-	padding:10px 14px; border:none; border-radius:10px; cursor:pointer;
-	background:#777; color:#fff; box-shadow:none; outline:none; margin-left:8px;
-	}
+        .prs-cover-overlay{
+        position:absolute; inset:0;
+        display:flex; align-items:center; justify-content:center;
+        pointer-events:auto; /* ← así los botones siempre reciben el click */
+        padding:16px;
+        }
+        .prs-cover-actions{
+        display:flex; flex-direction:column; align-items:center; justify-content:center;
+        gap:10px; width:100%; text-align:center;
+        }
+        .prs-cover-buttons{
+        display:flex; flex-wrap:wrap; justify-content:center; gap:8px;
+        }
+        #prs-cover-open,
+        #prs-cover-fetch{
+        pointer-events:auto;
+        padding:10px 14px; border:none; border-radius:10px; cursor:pointer;
+        background:#111; color:#fff; box-shadow:none; outline:none;
+        }
+        #prs-cover-fetch[disabled]{
+        opacity:0.65; cursor:not-allowed;
+        }
+        #prs-cover-status{
+        font-size:12px; color:#222; min-height:1.2em;
+        text-align:center; padding:0 6px;
+        }
+        #prs-cover-status.is-error{ color:#b3261e; }
+        .prs-cover-frame.has-image #prs-cover-status{
+        color:#fff; text-shadow:0 1px 2px rgba(0,0,0,.6);
+        }
+        .prs-cover-frame.has-image #prs-cover-status.is-error{
+        color:#ffd6d6;
+        }
 
 	/* Mostrar overlay siempre si no hay imagen; o solo al hover si hay imagen */
 	.prs-cover-frame.has-image .prs-cover-overlay{ opacity:0; transition:opacity .2s; }

--- a/modules/reading/includes/class-activator.php
+++ b/modules/reading/includes/class-activator.php
@@ -85,6 +85,7 @@ class Politeia_Reading_Activator {
             counterparty_name  VARCHAR(255) NULL,
             counterparty_email VARCHAR(190) NULL,
             cover_attachment_id_user BIGINT UNSIGNED NULL,
+            cover_url_user VARCHAR(800) NULL,
             language VARCHAR(50) NULL,
             notes TEXT NULL,
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -143,8 +144,10 @@ class Politeia_Reading_Activator {
 
 		// NUEVO: asegurar cover_url en books
 		global $wpdb;
-		$books = $wpdb->prefix . 'politeia_books';
+		$books      = $wpdb->prefix . 'politeia_books';
+		$user_books = $wpdb->prefix . 'politeia_user_books';
 		self::maybe_add_column( $books, 'cover_url', 'VARCHAR(800) NULL' );
+		self::maybe_add_column( $user_books, 'cover_url_user', 'VARCHAR(800) NULL' );
 
 		self::migrate_books_hash_and_unique(); // <-- mantiene tu migración de hash/unique
 		self::ensure_unique_user_book();       // robustez por si faltara el UNIQUE

--- a/modules/reading/templates/features/cover-upload/cover-upload.js
+++ b/modules/reading/templates/features/cover-upload/cover-upload.js
@@ -8,9 +8,53 @@
     };
   }
 
+  function getAjaxUrl() {
+    return (window.PRS_COVER && PRS_COVER.ajax) || '';
+  }
+
+  function getFetchNonce() {
+    if (window.PRS_BOOK && window.PRS_BOOK.fetchNonce) {
+      return window.PRS_BOOK.fetchNonce;
+    }
+    return (window.PRS_COVER && PRS_COVER.fetchNonce) || '';
+  }
+
   // Helpers
   const $ = (s, r = document) => r.querySelector(s);
   const el = (t, cls) => { const e = document.createElement(t); if (cls) e.className = cls; return e; };
+
+  function setOverlayStatus(text, isError = false) {
+    const status = document.getElementById('prs-cover-status');
+    if (!status) return;
+    status.textContent = text || '';
+    status.classList.toggle('is-error', !!isError);
+  }
+
+  function ensureCoverImage(url) {
+    if (!url) return;
+    const frame = document.getElementById('prs-cover-frame');
+    if (!frame) return;
+
+    let img = document.getElementById('prs-cover-img');
+    const placeholder = document.getElementById('prs-cover-placeholder');
+
+    if (img) {
+      img.src = url;
+    } else {
+      img = document.createElement('img');
+      img.id = 'prs-cover-img';
+      img.className = 'prs-cover-img';
+      img.alt = '';
+      img.src = url;
+      frame.appendChild(img);
+    }
+
+    if (placeholder && placeholder.parentNode) {
+      placeholder.parentNode.removeChild(placeholder);
+    }
+
+    frame.classList.add('has-image');
+  }
 
   // Estado de la imagen en el stage
   const STAGE_W = 280; // más pequeño => cabe sin scroll
@@ -185,7 +229,7 @@
       });
 
       try {
-        const resp = await fetch((window.PRS_COVER && PRS_COVER.ajax) || '', {
+        const resp = await fetch(getAjaxUrl(), {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
           credentials: 'same-origin',
@@ -200,21 +244,8 @@
 
         // Reemplazar la portada del front
         const src = out.data.src;
-        const img = document.getElementById('prs-cover-img');
-        const ph  = document.getElementById('prs-cover-placeholder');
-        const frame = document.getElementById('prs-cover-frame');
-
-        if (img) {
-          img.src = src + (src.indexOf('?') >= 0 ? '&' : '?') + 't=' + Date.now();
-        } else if (frame) {
-          if (ph && ph.parentNode) ph.parentNode.removeChild(ph);
-          const n = document.createElement('img');
-          n.id = 'prs-cover-img';
-          n.className = 'prs-cover-img';
-          n.alt = '';
-          n.src = src;
-          frame.appendChild(n);
-        }
+        const bust = src + (src.indexOf('?') >= 0 ? '&' : '?') + 't=' + Date.now();
+        ensureCoverImage(bust);
 
         closeModal();
       } catch (e) {
@@ -230,5 +261,79 @@
     if (!btn) return;
     e.preventDefault();
     openModal();
+  });
+
+  async function onFetchRemote(button) {
+    const { user_book_id, book_id } = getContext();
+    if (!user_book_id || !book_id) {
+      setOverlayStatus('Missing book context', true);
+      return;
+    }
+
+    const nonce = getFetchNonce();
+    if (!nonce) {
+      setOverlayStatus('Security token missing', true);
+      return;
+    }
+
+    button.disabled = true;
+    setOverlayStatus('Fetching…', false);
+
+    const body = new URLSearchParams({
+      action: 'prs_cover_fetch_remote',
+      user_book_id,
+      book_id,
+      _ajax_nonce: nonce
+    });
+
+    try {
+      const resp = await fetch(getAjaxUrl(), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+        credentials: 'same-origin',
+        body
+      });
+
+      const text = await resp.text();
+      let out = null;
+      try {
+        out = JSON.parse(text);
+      } catch (parseErr) {
+        throw new Error('Unexpected response');
+      }
+
+      if (!resp.ok || !out || !out.success) {
+        const msg = out && out.data && out.data.message ? out.data.message : (out && out.message) ? out.message : 'No cover found';
+        throw new Error(msg);
+      }
+
+      const data = out.data || {};
+      if (!data.url) {
+        throw new Error('No cover found');
+      }
+
+      ensureCoverImage(data.url);
+
+      let provider = 'the selected provider';
+      if (data.source === 'open_library') {
+        provider = 'Open Library';
+      } else if (data.source === 'google_books') {
+        provider = 'Google Books';
+      }
+
+      setOverlayStatus(`Cover found from ${provider}.`, false);
+    } catch (error) {
+      console.error('[PRS] cover fetch error', error);
+      setOverlayStatus(error.message || 'Error fetching cover', true);
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  document.addEventListener('click', (e) => {
+    const fetchBtn = e.target.closest('#prs-cover-fetch');
+    if (!fetchBtn) return;
+    e.preventDefault();
+    onFetchRemote(fetchBtn);
   });
 })();

--- a/modules/reading/templates/features/cover-upload/cover-upload.js
+++ b/modules/reading/templates/features/cover-upload/cover-upload.js
@@ -39,6 +39,10 @@
     const placeholder = document.getElementById('prs-cover-placeholder');
 
     if (img) {
+      img.removeAttribute('srcset');
+      img.removeAttribute('sizes');
+      img.removeAttribute('data-src');
+      img.removeAttribute('data-srcset');
       img.src = url;
     } else {
       img = document.createElement('img');
@@ -46,6 +50,8 @@
       img.className = 'prs-cover-img';
       img.alt = '';
       img.src = url;
+      img.removeAttribute('srcset');
+      img.removeAttribute('sizes');
       frame.appendChild(img);
     }
 
@@ -312,7 +318,8 @@
         throw new Error('No cover found');
       }
 
-      ensureCoverImage(data.url);
+      const bust = data.url + (data.url.indexOf('?') >= 0 ? '&' : '?') + 't=' + Date.now();
+      ensureCoverImage(bust);
 
       let provider = 'the selected provider';
       if (data.source === 'open_library') {

--- a/modules/reading/templates/features/cover-upload/cover-upload.php
+++ b/modules/reading/templates/features/cover-upload/cover-upload.php
@@ -12,7 +12,8 @@ class PRS_Cover_Upload_Feature {
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'assets' ) );
 		add_shortcode( 'prs_cover_button', array( __CLASS__, 'shortcode_button' ) );
 		add_action( 'wp_ajax_prs_cover_save_crop', array( __CLASS__, 'ajax_save_crop' ) );
-	}
+		add_action( 'wp_ajax_prs_cover_fetch_remote', array( __CLASS__, 'ajax_fetch_remote' ) );
+}
 
 	public static function assets() {
 		// Solo en la pantalla del libro (usas query var prs_book_slug en tu template).
@@ -48,16 +49,26 @@ class PRS_Cover_Upload_Feature {
 			array(
 				'ajax'        => admin_url( 'admin-ajax.php' ),
 				'nonce'       => wp_create_nonce( 'prs_cover_save_crop' ),
+				'fetchNonce'  => wp_create_nonce( 'prs_cover_fetch_remote' ),
 				'coverWidth'  => 240,
 				'coverHeight' => 450,
 				'onlyOne'     => 1,
 			)
 		);
-	}
+}
 
 	public static function shortcode_button( $atts ) {
-		// Botón compacto para insertar sobre la portada
-		return '<button type="button" id="prs-cover-open" class="prs-btn prs-cover-btn">Upload Book Cover</button>';
+		ob_start();
+		?>
+		<div class="prs-cover-actions">
+			<div class="prs-cover-buttons">
+				<button type="button" id="prs-cover-open" class="prs-btn prs-cover-btn">Upload Book Cover</button>
+				<button type="button" id="prs-cover-fetch" class="prs-btn prs-cover-btn">Get Book Cover</button>
+			</div>
+			<span id="prs-cover-status" aria-live="polite"></span>
+		</div>
+		<?php
+		return ob_get_clean();
 	}
 
 	/**
@@ -177,6 +188,7 @@ class PRS_Cover_Upload_Feature {
 			$t,
 			array(
 				'cover_attachment_id_user' => (int) $att_id,
+				'cover_url_user'          => null,
 				'updated_at'               => current_time( 'mysql', true ),
 			),
 			array( 'id' => $user_book_id )
@@ -190,6 +202,246 @@ class PRS_Cover_Upload_Feature {
 				'src' => $src ?: '',
 			)
 		);
+}
+
+	public static function ajax_fetch_remote() {
+		if ( ! is_user_logged_in() ) {
+			wp_send_json_error( array( 'message' => __( 'Authentication required', 'politeia-reading' ) ), 401 );
+		}
+
+		$nonce = isset( $_POST['_ajax_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_ajax_nonce'] ) ) : '';
+		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'prs_cover_fetch_remote' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Security check failed', 'politeia-reading' ) ), 403 );
+		}
+
+		$user_id      = get_current_user_id();
+		$user_book_id = isset( $_POST['user_book_id'] ) ? absint( $_POST['user_book_id'] ) : 0;
+		$book_id      = isset( $_POST['book_id'] ) ? absint( $_POST['book_id'] ) : 0;
+
+		if ( ! $user_book_id || ! $book_id ) {
+			wp_send_json_error( array( 'message' => __( 'Missing parameters', 'politeia-reading' ) ), 400 );
+		}
+
+		global $wpdb;
+		$user_books_table = $wpdb->prefix . 'politeia_user_books';
+		$books_table      = $wpdb->prefix . 'politeia_books';
+
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT id FROM {$user_books_table} WHERE id = %d AND user_id = %d AND book_id = %d LIMIT 1",
+				$user_book_id,
+				$user_id,
+				$book_id
+			)
+		);
+
+		if ( ! $row ) {
+			wp_send_json_error( array( 'message' => __( 'You cannot modify this book.', 'politeia-reading' ) ), 403 );
+		}
+
+		$book = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT title, author FROM {$books_table} WHERE id = %d LIMIT 1",
+				$book_id
+			)
+		);
+
+		if ( ! $book ) {
+			wp_send_json_error( array( 'message' => __( 'Book not found.', 'politeia-reading' ) ), 404 );
+		}
+
+		$title  = isset( $book->title ) ? wp_strip_all_tags( $book->title ) : '';
+		$author = isset( $book->author ) ? wp_strip_all_tags( $book->author ) : '';
+
+		$providers = array( 'open_library', 'google_books' );
+		$result    = null;
+
+		foreach ( $providers as $provider ) {
+			if ( 'open_library' === $provider ) {
+				$result = self::fetch_from_open_library( $title, $author );
+			} elseif ( 'google_books' === $provider ) {
+				$result = self::fetch_from_google_books( $title, $author );
+			}
+
+			if ( $result ) {
+				break;
+			}
+		}
+
+		if ( ! $result || empty( $result['url'] ) ) {
+			wp_send_json_error( array( 'message' => __( 'No cover found', 'politeia-reading' ) ), 404 );
+		}
+
+		$url    = self::normalize_remote_url( $result['url'] );
+		$source = isset( $result['source'] ) ? $result['source'] : '';
+
+		if ( ! $url ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid cover URL returned', 'politeia-reading' ) ), 500 );
+		}
+
+		$wpdb->update(
+			$user_books_table,
+			array(
+				'cover_url_user'           => $url,
+				'cover_attachment_id_user' => null,
+				'updated_at'                => current_time( 'mysql', true ),
+			),
+			array( 'id' => $user_book_id )
+		);
+
+		wp_send_json_success(
+			array(
+				'url'    => esc_url( $url ),
+				'source' => $source,
+			)
+		);
+	}
+
+	private static function fetch_from_open_library( $title, $author ) {
+		$args = array(
+			'limit' => 5,
+		);
+
+		if ( $title ) {
+			$args['title'] = $title;
+		}
+
+		if ( $author ) {
+			$args['author'] = $author;
+		}
+
+		$url     = add_query_arg( $args, 'https://openlibrary.org/search.json' );
+		$request = wp_remote_get(
+			$url,
+			array(
+				'timeout' => 10,
+			)
+		);
+
+		if ( is_wp_error( $request ) ) {
+			return null;
+		}
+
+		$code = wp_remote_retrieve_response_code( $request );
+		if ( 200 !== (int) $code ) {
+			return null;
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $request ), true );
+		if ( empty( $data['docs'] ) || ! is_array( $data['docs'] ) ) {
+			return null;
+		}
+
+		foreach ( $data['docs'] as $doc ) {
+			if ( ! empty( $doc['cover_i'] ) ) {
+				$cover_id = (int) $doc['cover_i'];
+				if ( $cover_id > 0 ) {
+					return array(
+						'url'    => sprintf( 'https://covers.openlibrary.org/b/id/%d-L.jpg', $cover_id ),
+						'source' => 'open_library',
+					);
+				}
+			}
+
+			if ( ! empty( $doc['isbn'] ) && is_array( $doc['isbn'] ) ) {
+				foreach ( $doc['isbn'] as $isbn ) {
+					$isbn = preg_replace( '/[^0-9Xx]/', '', (string) $isbn );
+					if ( $isbn ) {
+						return array(
+							'url'    => sprintf( 'https://covers.openlibrary.org/b/isbn/%s-L.jpg', rawurlencode( $isbn ) ),
+							'source' => 'open_library',
+						);
+					}
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static function fetch_from_google_books( $title, $author ) {
+		$query_parts = array();
+
+		if ( $title ) {
+			$query_parts[] = 'intitle:' . $title;
+		}
+
+		if ( $author ) {
+			$query_parts[] = 'inauthor:' . $author;
+		}
+
+		if ( empty( $query_parts ) ) {
+			return null;
+		}
+
+		$url      = add_query_arg(
+			array(
+				'q'          => implode( ' ', $query_parts ),
+				'maxResults' => 5,
+			),
+			'https://www.googleapis.com/books/v1/volumes'
+		);
+		$request = wp_remote_get(
+			$url,
+			array(
+				'timeout' => 10,
+			)
+		);
+
+		if ( is_wp_error( $request ) ) {
+			return null;
+		}
+
+		$code = wp_remote_retrieve_response_code( $request );
+		if ( 200 !== (int) $code ) {
+			return null;
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $request ), true );
+		if ( empty( $data['items'] ) || ! is_array( $data['items'] ) ) {
+			return null;
+		}
+
+		$priority = array( 'extraLarge', 'large', 'medium', 'small', 'thumbnail', 'smallThumbnail' );
+
+		foreach ( $data['items'] as $item ) {
+			if ( empty( $item['volumeInfo']['imageLinks'] ) || ! is_array( $item['volumeInfo']['imageLinks'] ) ) {
+				continue;
+			}
+
+			foreach ( $priority as $key ) {
+				if ( empty( $item['volumeInfo']['imageLinks'][ $key ] ) ) {
+					continue;
+				}
+
+				$url = self::normalize_remote_url( $item['volumeInfo']['imageLinks'][ $key ] );
+				if ( $url ) {
+					return array(
+						'url'    => $url,
+						'source' => 'google_books',
+					);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static function normalize_remote_url( $url ) {
+		$url = trim( (string) $url );
+		if ( '' === $url ) {
+			return '';
+		}
+
+		if ( strpos( $url, '//' ) === 0 ) {
+			$url = 'https:' . $url;
+		}
+
+		if ( 0 === strpos( $url, 'http://' ) ) {
+			$url = 'https://' . substr( $url, 7 );
+		}
+
+		return esc_url_raw( $url, array( 'http', 'https' ) );
 	}
 }
 PRS_Cover_Upload_Feature::init();

--- a/modules/reading/templates/features/cover-upload/cover-upload.php
+++ b/modules/reading/templates/features/cover-upload/cover-upload.php
@@ -279,15 +279,37 @@ class PRS_Cover_Upload_Feature {
 			wp_send_json_error( array( 'message' => __( 'Invalid cover URL returned', 'politeia-reading' ) ), 500 );
 		}
 
-		$wpdb->update(
-			$user_books_table,
-			array(
-				'cover_url_user'           => $url,
-				'cover_attachment_id_user' => null,
-				'updated_at'                => current_time( 'mysql', true ),
-			),
-			array( 'id' => $user_book_id )
-		);
+                $key = 'u' . $user_id . 'ub' . $user_book_id;
+
+                $existing_attachments = get_posts(
+                        array(
+                                'post_type'      => 'attachment',
+                                'post_status'    => 'inherit',
+                                'fields'         => 'ids',
+                                'posts_per_page' => -1,
+                                'author'         => $user_id,
+                                'meta_query'     => array(
+                                        array(
+                                                'key'   => '_prs_cover_key',
+                                                'value' => $key,
+                                        ),
+                                ),
+                        )
+                );
+
+                foreach ( $existing_attachments as $attachment_id ) {
+                        wp_delete_attachment( $attachment_id, true );
+                }
+
+                $wpdb->update(
+                        $user_books_table,
+                        array(
+                                'cover_url_user'           => $url,
+                                'cover_attachment_id_user' => null,
+                                'updated_at'                => current_time( 'mysql', true ),
+                        ),
+                        array( 'id' => $user_book_id )
+                );
 
 		wp_send_json_success(
 			array(

--- a/modules/reading/templates/my-book-single.php
+++ b/modules/reading/templates/my-book-single.php
@@ -84,12 +84,13 @@ wp_localize_script(
 	#prs-reading-sessions{ grid-column:1 / 4; grid-row:3; min-height:320px; }
 
 	/* Frame portada */
-	.prs-cover-frame{
-	position:relative; width:100%; height:auto; overflow:hidden;
-	background:#eee; border-radius:12px;
-	}
-	.prs-cover-img{ width:100%; height:100%; object-fit:cover; display:block; }
-	.prs-cover-placeholder{ width:100%; height:100%; background:#ddd; }
+        .prs-cover-frame{
+        position:relative; width:280px; max-width:100%;
+        height:auto; overflow:hidden;
+        background:#eee; border-radius:12px; margin:0 auto;
+        }
+        .prs-cover-img{ width:100%; height:auto; display:block; object-fit:contain; }
+        .prs-cover-placeholder{ width:100%; aspect-ratio:280 / 450; background:#ddd; }
 
 	/* Tipos y tablas */
 	.prs-box h2{ margin:0 0 8px; }


### PR DESCRIPTION
## Summary
- add a remote cover fetch workflow that stores provider URLs for each user book
- surface both Upload and Get Cover controls on the cover overlay with status messaging
- update the cover frame rendering and styling to handle fetched URLs alongside attachments

## Testing
- php -l modules/reading/templates/features/cover-upload/cover-upload.php
- php -l modules/reading/templates/my-book-single.php
- php -l modules/reading/includes/class-activator.php

------
https://chatgpt.com/codex/tasks/task_e_68ce8ae49cc4833288f891a3139b7649