### PR TITLE
Render confirmation table with chat input

### DIFF
--- a/modules/chatgpt/modules/shortcode/confirm-table-shortcode.php
+++ b/modules/chatgpt/modules/shortcode/confirm-table-shortcode.php
@@ -203,7 +203,8 @@ function politeia_confirm_table_shortcode() {
                 .pol-btn-primary{background:#1a73e8;color:#fff;border-color:#1a73e8}
                 .pol-btn-ghost{background:#eaf2fe;border-color:#1b73e8;color:#1b73e8;border:none}
                 .pol-btn-ghost:hover{background:#1b73e8;color:#fff}
-		.pol-edit{margin-left:8px;font-size:12px;line-height:1;border:0;background:#f0f0f0;border-radius:8px;padding:4px 6px;cursor:pointer}
+                .pol-edit{margin-left:8px;font-size:12px;line-height:1;border:0;background:#f0f0f0;border-radius:8px;padding:4px 6px;cursor:pointer;color:#1b73e8}
+                .pol-edit:hover{background:#1b73e8;color:#fff}
 		.pol-input{width:100%;max-width:600px;padding:6px 8px;border:1px solid #ddd;border-radius:8px;font:inherit;}
 		.pol-row.saving{opacity:.6}
 		.pill{display:inline-block;padding:.25rem .6rem;border-radius:9999px;font-size:.85em;border:1px solid #bde5c8;background:#e7f7ec;color:#166534;margin-right:8px}

--- a/modules/chatgpt/modules/shortcode/confirm-table-shortcode.php
+++ b/modules/chatgpt/modules/shortcode/confirm-table-shortcode.php
@@ -192,16 +192,17 @@ function politeia_confirm_table_shortcode() {
 	</div>
 
 	<style>
-		.pol-card{background:#fff;border-radius:14px;padding:14px 16px;box-shadow:0 6px 20px rgba(0,0,0,.06);}
-		.pol-card__header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;}
-		.pol-title{margin:0;font-weight:600;}
-		.pol-table{width:100%;border-collapse:collapse;}
-		.pol-table th,.pol-table td{padding:14px 16px;border-top:1px solid #eee;text-align:left;vertical-align:middle;}
-		.pol-btn{padding:6px 10px;border-radius:8px;border:1px solid #e6e6e6;background:#f7f7f7;cursor:pointer;font:inherit}
-		.pol-btn[disabled]{opacity:.45;cursor:not-allowed}
-		.pol-btn-primary{background:#1a73e8;color:#fff;border-color:#1a73e8}
-               .pol-btn-ghost{background:#eaf2fe;border-color:#1b73e8;color:#1b73e8;border:none}
-               .pol-btn-ghost:hover{background:#1b73e8;color:#fff}
+                .pol-card{background:#fff;border-radius:14px;padding:14px 16px;box-shadow:0 6px 20px rgba(0,0,0,.06);}
+                .pol-card__header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;}
+                .pol-title{margin:0;font-weight:600;}
+                .pol-table{width:100%;border-collapse:collapse;}
+                .pol-table thead{background:#f8f8f8;}
+                .pol-table th,.pol-table td{padding:14px 16px;border-top:1px solid #eee;text-align:left;vertical-align:middle;}
+                .pol-btn{padding:6px 10px;border-radius:8px;border:1px solid #e6e6e6;background:#f7f7f7;cursor:pointer;font:inherit}
+                .pol-btn[disabled]{opacity:.45;cursor:not-allowed}
+                .pol-btn-primary{background:#1a73e8;color:#fff;border-color:#1a73e8}
+                .pol-btn-ghost{background:#eaf2fe;border-color:#1b73e8;color:#1b73e8;border:none}
+                .pol-btn-ghost:hover{background:#1b73e8;color:#fff}
 		.pol-edit{margin-left:8px;font-size:12px;line-height:1;border:0;background:#f0f0f0;border-radius:8px;padding:4px 6px;cursor:pointer}
 		.pol-input{width:100%;max-width:600px;padding:6px 8px;border:1px solid #ddd;border-radius:8px;font:inherit;}
 		.pol-row.saving{opacity:.6}

--- a/modules/chatgpt/modules/shortcode/confirm-table-shortcode.php
+++ b/modules/chatgpt/modules/shortcode/confirm-table-shortcode.php
@@ -100,17 +100,22 @@ function politeia_confirm_table_shortcode() {
 	$rows = array_merge( $ef_rows, $db_rows );
 
 	// Conteos para UI
-	$total_rows   = count($rows);
-	$confirmables = 0;
-	foreach ( $rows as $r ) {
-		// confirmable si NO está marcado como in_shelf
-		if ( empty($r['already_in_shelf']) ) {
-			$confirmables++;
-		}
-	}
+        $total_rows   = count($rows);
+        $confirmables = 0;
+        foreach ( $rows as $r ) {
+                // confirmable si NO está marcado como in_shelf
+                if ( empty($r['already_in_shelf']) ) {
+                        $confirmables++;
+                }
+        }
 
-	ob_start();
-	$nonce = wp_create_nonce('politeia-chatgpt-nonce');
+        if ( $confirmables === 0 ) {
+                delete_transient( $ephem_key );
+                return '';
+        }
+
+        ob_start();
+        $nonce = wp_create_nonce('politeia-chatgpt-nonce');
 	?>
 	<div id="pol-confirm" class="pol-confirm" data-nonce="<?php echo esc_attr($nonce); ?>">
 		<div class="pol-card">

--- a/modules/chatgpt/modules/shortcode/confirm-table-shortcode.php
+++ b/modules/chatgpt/modules/shortcode/confirm-table-shortcode.php
@@ -200,7 +200,8 @@ function politeia_confirm_table_shortcode() {
 		.pol-btn{padding:6px 10px;border-radius:8px;border:1px solid #e6e6e6;background:#f7f7f7;cursor:pointer;font:inherit}
 		.pol-btn[disabled]{opacity:.45;cursor:not-allowed}
 		.pol-btn-primary{background:#1a73e8;color:#fff;border-color:#1a73e8}
-		.pol-btn-ghost{background:#eaf2fe;border-color:#cfe0fd}
+               .pol-btn-ghost{background:#eaf2fe;border-color:#1b73e8;color:#1b73e8;border:none}
+               .pol-btn-ghost:hover{background:#1b73e8;color:#fff}
 		.pol-edit{margin-left:8px;font-size:12px;line-height:1;border:0;background:#f0f0f0;border-radius:8px;padding:4px 6px;cursor:pointer}
 		.pol-input{width:100%;max-width:600px;padding:6px 8px;border:1px solid #ddd;border-radius:8px;font:inherit;}
 		.pol-row.saving{opacity:.6}

--- a/modules/chatgpt/politeia-chatgpt-shortcode.php
+++ b/modules/chatgpt/politeia-chatgpt-shortcode.php
@@ -71,9 +71,14 @@ function politeia_chatgpt_shortcode_callback() {
 
                 <div id="politeia-chat-status"></div>
 
+                <?php
+                $politeia_confirm_markup = do_shortcode('[politeia_confirm_table]');
+                if ( trim($politeia_confirm_markup) !== '' ) :
+                ?>
                 <div class="politeia-chat-confirm">
-                        <?php echo do_shortcode('[politeia_confirm_table]'); ?>
+                        <?php echo $politeia_confirm_markup; ?>
                 </div>
+                <?php endif; ?>
         </div>
 
 	<script>

--- a/modules/chatgpt/politeia-chatgpt-shortcode.php
+++ b/modules/chatgpt/politeia-chatgpt-shortcode.php
@@ -42,16 +42,17 @@ function politeia_chatgpt_shortcode_callback() {
 	ob_start();
 	?>
 	<style>
-		.politeia-chat-container { max-width: 980px; margin: 20px auto; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
-		.politeia-chat-input-bar { display:flex; align-items:center; gap:6px; padding:8px; border:1px solid #e0e0e0; border-radius:999px; background:#fff; box-shadow:0 4px 10px rgba(0,0,0,.07); }
-		#politeia-chat-prompt { flex-grow:1; border:none; outline:none; background:transparent; font-size:16px; padding:8px; resize:none; line-height:1.5; }
-		.politeia-icon-button { background:transparent; border:none; cursor:pointer; padding:8px; display:inline-flex; align-items:center; justify-content:center; color:#555; border-radius:50%; }
-		.politeia-icon-button:hover { background-color:#f0f0f0; }
-		#politeia-chat-status { margin-top:10px; text-align:center; color:#333; min-height:1.2em; }
-	</style>
+                .politeia-chat-container { max-width: 980px; margin: 20px auto; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
+                .politeia-chat-input-bar { display:flex; align-items:center; gap:6px; padding:8px; border:1px solid #e0e0e0; border-radius:999px; background:#fff; box-shadow:0 4px 10px rgba(0,0,0,.07); }
+                #politeia-chat-prompt { flex-grow:1; border:none; outline:none; background:transparent; font-size:16px; padding:8px; resize:none; line-height:1.5; }
+                .politeia-icon-button { background:transparent; border:none; cursor:pointer; padding:8px; display:inline-flex; align-items:center; justify-content:center; color:#555; border-radius:50%; }
+                .politeia-icon-button:hover { background-color:#f0f0f0; }
+                #politeia-chat-status { margin-top:10px; text-align:center; color:#333; min-height:1.2em; }
+                .politeia-chat-confirm { margin-top:24px; }
+        </style>
 
-	<div class="politeia-chat-container">
-		<div class="politeia-chat-input-bar">
+        <div class="politeia-chat-container">
+                <div class="politeia-chat-input-bar">
 			<input type="file" id="politeia-file-upload" accept="image/*" style="display:none;" />
 			<label for="politeia-file-upload" class="politeia-icon-button" title="Subir imagen de tus libros">
 				<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"></path></svg>
@@ -68,8 +69,12 @@ function politeia_chatgpt_shortcode_callback() {
 			</button>
 		</div>
 
-		<div id="politeia-chat-status"></div>
-	</div>
+                <div id="politeia-chat-status"></div>
+
+                <div class="politeia-chat-confirm">
+                        <?php echo do_shortcode('[politeia_confirm_table]'); ?>
+                </div>
+        </div>
 
 	<script>
 	// Escucha global para refrescar la tabla de confirmación (efímeros + pending)


### PR DESCRIPTION
## Summary
- render the confirmation queue table directly within the chat input shortcode output
- ensure the embedded table has spacing from the input bar for readability

## Testing
- php -l modules/chatgpt/politeia-chatgpt-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68cec04040908332965f298805b937f7