### PR TITLE
Redesign my library table layout

### DIFF
--- a/modules/chatgpt/politeia-chatgpt-shortcode.php
+++ b/modules/chatgpt/politeia-chatgpt-shortcode.php
@@ -42,13 +42,13 @@ function politeia_chatgpt_shortcode_callback() {
 	ob_start();
 	?>
 	<style>
-                .politeia-chat-container { max-width: 980px; margin: 20px auto; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
+                .politeia-chat-container { max-width: 980px; margin: auto; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
                 .politeia-chat-input-bar { display:flex; align-items:center; gap:6px; padding:8px; border:1px solid #e0e0e0; border-radius:999px; background:#fff; box-shadow:0 4px 10px rgba(0,0,0,.07); }
                 #politeia-chat-prompt { flex-grow:1; border:none; outline:none; background:transparent; font-size:16px; padding:8px; resize:none; line-height:1.5; }
                 .politeia-icon-button { background:transparent; border:none; cursor:pointer; padding:8px; display:inline-flex; align-items:center; justify-content:center; color:#555; border-radius:50%; }
                 .politeia-icon-button:hover { background-color:#f0f0f0; }
                 #politeia-chat-status { margin-top:10px; text-align:center; color:#333; min-height:1.2em; }
-                .politeia-chat-confirm { margin-top:24px; }
+                .politeia-chat-confirm { margin-top:0px; }
         </style>
 
         <div class="politeia-chat-container">

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -94,6 +94,80 @@
         font-size: 0.85rem;
 }
 
+#prs-library .prs-library__pages {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        flex-wrap: wrap;
+}
+
+#prs-library .prs-library__pages-display {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        flex-wrap: wrap;
+}
+
+#prs-library .prs-library__pages-label {
+        font-weight: 600;
+        color: #444;
+}
+
+#prs-library .prs-library__pages-value {
+        color: #333;
+}
+
+#prs-library .prs-library__pages-edit {
+        background: none;
+        border: 0;
+        color: #0073aa;
+        cursor: pointer;
+        padding: 0;
+        font-size: 0.8rem;
+        font-weight: 600;
+}
+
+#prs-library .prs-library__pages-edit:hover,
+#prs-library .prs-library__pages-edit:focus {
+        text-decoration: underline;
+}
+
+#prs-library .prs-library__pages-input {
+        display: none;
+        width: 86px;
+        padding: 4px 6px;
+        border: 1px solid #d0d0d0;
+        border-radius: 4px;
+        font-size: 0.85rem;
+        color: #333;
+        background: #fff;
+}
+
+#prs-library .prs-library__pages-input:focus {
+        outline: 2px solid #0073aa;
+        outline-offset: 1px;
+}
+
+#prs-library .prs-library__pages--editing .prs-library__pages-display {
+        display: none;
+}
+
+#prs-library .prs-library__pages--editing .prs-library__pages-input {
+        display: inline-block;
+}
+
+#prs-library .prs-library__pages-error {
+        display: none;
+        font-size: 0.7rem;
+        color: #b00020;
+        flex-basis: 100%;
+        margin-top: 4px;
+}
+
+#prs-library .prs-library__pages--error .prs-library__pages-error {
+        display: inline;
+}
+
 #prs-library .prs-library__actions {
         flex: 1 1 0;
         display: flex;

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -1,5 +1,234 @@
 .prs-table { width:100%; border-collapse: collapse; }
 .prs-table th, .prs-table td { padding:8px 10px; border-bottom:1px solid #eee; text-align:left; }
+
+/* My Library redesign */
+#prs-library {
+        width: 100%;
+        border-collapse: collapse;
+        background: #fff;
+}
+
+#prs-library thead th {
+        padding: 14px 18px;
+        background: #f5f5f5;
+        color: #333;
+        font-weight: 600;
+}
+
+#prs-library tbody td {
+        padding: 18px 20px;
+        border-bottom: 1px solid #eee;
+        vertical-align: top;
+}
+
+#prs-library .prs-library__info {
+        width: 33%;
+        min-width: 240px;
+        display: flex;
+        gap: 16px;
+        align-items: flex-start;
+}
+
+#prs-library .prs-library__cover {
+        width: 64px;
+        flex-shrink: 0;
+}
+
+#prs-library .prs-library__cover-image {
+        display: block;
+        width: 100%;
+        height: auto;
+        border-radius: 8px;
+        object-fit: cover;
+}
+
+#prs-library .prs-library__cover-placeholder {
+        width: 100%;
+        padding-top: 150%;
+        border-radius: 8px;
+        background: #e6e6e6;
+}
+
+#prs-library .prs-library__details {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+}
+
+#prs-library .prs-library__title {
+        font-weight: 600;
+        font-size: 1rem;
+        color: #111;
+        text-decoration: none;
+}
+
+#prs-library .prs-library__title:hover,
+#prs-library .prs-library__title:focus {
+        text-decoration: underline;
+}
+
+#prs-library .prs-library__meta {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        color: #555;
+        font-size: 0.85rem;
+}
+
+#prs-library .prs-library__actions {
+        width: 67%;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 20px;
+}
+
+#prs-library .prs-library__controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 18px;
+}
+
+#prs-library .prs-library__field {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        min-width: 170px;
+}
+
+#prs-library .prs-library__field label {
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: #555;
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
+}
+
+#prs-library select.prs-reading-status,
+#prs-library select.prs-owning-status {
+        min-width: 170px;
+        padding: 8px 12px;
+        border: 1px solid #dcdcdc;
+        border-radius: 8px;
+        background-color: #fff;
+        color: #333;
+}
+
+#prs-library .prs-library__extras {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 16px;
+}
+
+#prs-library .prs-library__progress {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        min-width: 140px;
+}
+
+#prs-library .prs-library__progress-track {
+        position: relative;
+        flex: 1;
+        height: 8px;
+        background: #e3e3e3;
+        border-radius: 999px;
+        overflow: hidden;
+}
+
+#prs-library .prs-library__progress-fill {
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        width: 0;
+        background: #ef6461;
+        border-radius: inherit;
+        transition: width 0.25s ease;
+}
+
+#prs-library .prs-library__progress-value {
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: #555;
+        min-width: 34px;
+        text-align: right;
+}
+
+#prs-library .prs-library__remove {
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+        border: 1px solid #d0d0d0;
+        background: #fff;
+        color: #666;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+#prs-library .prs-library__remove span {
+        font-size: 18px;
+        line-height: 1;
+}
+
+#prs-library .prs-library__remove:hover,
+#prs-library .prs-library__remove:focus {
+        background: #f8d7d4;
+        color: #a8322d;
+        border-color: #a8322d;
+}
+
+#prs-library .prs-library__remove:focus {
+        outline: 2px solid #a8322d;
+        outline-offset: 2px;
+}
+
+@media (max-width: 900px) {
+        #prs-library .prs-library__actions {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 16px;
+        }
+
+        #prs-library .prs-library__extras {
+                margin-left: 0;
+        }
+}
+
+@media (max-width: 640px) {
+        #prs-library thead {
+                display: none;
+        }
+
+        #prs-library tbody tr {
+                display: block;
+        }
+
+        #prs-library tbody td {
+                display: block;
+                width: 100%;
+                padding: 16px 0;
+                border-bottom: none;
+        }
+
+        #prs-library tbody tr + tr {
+                border-top: 1px solid #eee;
+                margin-top: 12px;
+        }
+
+        #prs-library .prs-library__actions {
+                width: 100%;
+        }
+
+        #prs-library .prs-library__extras {
+                width: 100%;
+                justify-content: space-between;
+        }
+}
 .prs-btn { padding:8px 14px; border-radius:6px; background:#111; color:#fff; border:0; cursor:pointer; }
 .prs-form label { display:block; margin:8px 0; }
 

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -191,18 +191,18 @@
 }
 
 #prs-library .prs-library__remove {
-        padding: 8px 16px;
-        border-radius: 999px;
+        padding: 4px 9px;
+        border-radius: 5px;
         border: 1px solid #d0d0d0;
         background: #fff;
         color: #666;
-        font-size: 0.85rem;
+        font-size: 0.65rem;
         font-weight: 600;
         line-height: 1.2;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        margin-top: 40px;
+        margin-top: 30px;
         cursor: pointer;
         transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -8,21 +8,40 @@
         background: #fff;
 }
 
-#prs-library thead th {
-        padding: 14px 18px;
+#prs-library tr {
+        display: flex;
+        width: 100%;
+}
+
+#prs-library thead tr {
         background: #f5f5f5;
+}
+
+#prs-library thead th {
+        flex: 1;
+        padding: 14px 18px;
         color: #333;
         font-weight: 600;
+        text-align: left;
+        border-bottom: none;
+}
+
+#prs-library tbody tr {
+        align-items: stretch;
+        border-bottom: 1px solid #eee;
+}
+
+#prs-library tbody tr:last-child {
+        border-bottom: none;
 }
 
 #prs-library tbody td {
         padding: 18px 20px;
-        border-bottom: 1px solid #eee;
-        vertical-align: top;
+        border-bottom: none;
 }
 
 #prs-library .prs-library__info {
-        width: 33%;
+        flex: 0 0 33%;
         min-width: 240px;
         display: flex;
         gap: 16px;
@@ -76,7 +95,7 @@
 }
 
 #prs-library .prs-library__actions {
-        width: 67%;
+        flex: 1 1 0;
         display: flex;
         flex-wrap: wrap;
         align-items: center;
@@ -157,22 +176,19 @@
 }
 
 #prs-library .prs-library__remove {
-        width: 36px;
-        height: 36px;
-        border-radius: 50%;
+        padding: 8px 16px;
+        border-radius: 999px;
         border: 1px solid #d0d0d0;
         background: #fff;
         color: #666;
+        font-size: 0.85rem;
+        font-weight: 600;
+        line-height: 1.2;
         display: inline-flex;
         align-items: center;
         justify-content: center;
         cursor: pointer;
         transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-#prs-library .prs-library__remove span {
-        font-size: 18px;
-        line-height: 1;
 }
 
 #prs-library .prs-library__remove:hover,
@@ -205,28 +221,33 @@
         }
 
         #prs-library tbody tr {
-                display: block;
+                flex-direction: column;
+                gap: 16px;
+                padding: 16px;
         }
 
         #prs-library tbody td {
-                display: block;
                 width: 100%;
-                padding: 16px 0;
-                border-bottom: none;
+                padding: 0;
         }
 
         #prs-library tbody tr + tr {
-                border-top: 1px solid #eee;
                 margin-top: 12px;
         }
 
+        #prs-library .prs-library__info,
         #prs-library .prs-library__actions {
-                width: 100%;
+                flex: 1 1 100%;
         }
 
         #prs-library .prs-library__extras {
                 width: 100%;
                 justify-content: space-between;
+        }
+
+        #prs-library .prs-library__remove {
+                width: 100%;
+                justify-content: center;
         }
 }
 .prs-btn { padding:8px 14px; border-radius:6px; background:#111; color:#fff; border:0; cursor:pointer; }

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -202,7 +202,7 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        margin-top: 40px;
+        margin-top: 30px;
         cursor: pointer;
         transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -87,9 +87,10 @@
 }
 
 #prs-library .prs-library__meta {
-        display: flex;
+        display: flex
+;
         flex-direction: column;
-        gap: 4px;
+        gap: 0px;
         color: #555;
         font-size: 0.85rem;
 }

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -136,8 +136,23 @@
 #prs-library .prs-library__extras {
         margin-left: auto;
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         gap: 16px;
+}
+
+#prs-library .prs-library__progress-field {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        min-width: 180px;
+}
+
+#prs-library .prs-library__progress-label {
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: #555;
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
 }
 
 #prs-library .prs-library__progress {
@@ -187,6 +202,7 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
+        margin-top: 40px;
         cursor: pointer;
         transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -98,7 +98,7 @@
         flex: 1 1 0;
         display: flex;
         flex-wrap: wrap;
-        align-items: center;
+        align-items: flex-start;
         gap: 20px;
 }
 
@@ -202,7 +202,7 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        margin-top: 30px;
+        margin-top: 40px;
         cursor: pointer;
         transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }

--- a/modules/reading/shortcodes/my-books.php
+++ b/modules/reading/shortcodes/my-books.php
@@ -95,13 +95,12 @@ add_shortcode(
 
 		ob_start(); ?>
         <div class="prs-library">
-                <table id="prs-library" class="prs-table">
-                <thead>
+               <table id="prs-library" class="prs-table">
+               <thead>
                         <tr>
-                        <th scope="col"><?php esc_html_e( 'Book', 'politeia-reading' ); ?></th>
-                        <th scope="col"><?php esc_html_e( 'Status & Actions', 'politeia-reading' ); ?></th>
+                        <th scope="colgroup" colspan="2"><?php esc_html_e( 'My Library', 'politeia-reading' ); ?></th>
                         </tr>
-                </thead>
+               </thead>
                 <tbody>
                         <?php foreach ( (array) $rows as $r ) :
                                 $slug     = $r->slug ?: sanitize_title( $r->title . '-' . $r->author . ( $r->year ? '-' . $r->year : '' ) );
@@ -217,7 +216,7 @@ add_shortcode(
                                                 <span class="prs-library__progress-value"><?php echo (int) $progress; ?>%</span>
                                         </div>
                                         <button type="button" class="prs-library__remove" aria-label="<?php esc_attr_e( 'Remove book', 'politeia-reading' ); ?>">
-                                                <span aria-hidden="true">&times;</span>
+                                                <?php esc_html_e( 'Remove', 'politeia-reading' ); ?>
                                         </button>
                                 </div>
                                 </td>

--- a/modules/reading/shortcodes/my-books.php
+++ b/modules/reading/shortcodes/my-books.php
@@ -115,8 +115,9 @@ add_shortcode(
                                         $progress = 50;
                                 }
 
-                                $reading_id = 'reading-status-' . (int) $r->user_book_id;
-                                $owning_id  = 'owning-status-' . (int) $r->user_book_id;
+                                $reading_id  = 'reading-status-' . (int) $r->user_book_id;
+                                $owning_id   = 'owning-status-' . (int) $r->user_book_id;
+                                $progress_id = 'reading-progress-' . (int) $r->user_book_id;
 
                                 $year_text  = $year ? sprintf( __( 'Published: %s', 'politeia-reading' ), $year ) : __( 'Published: —', 'politeia-reading' );
                                 $pages_text = $pages ? sprintf( __( 'Pages: %s', 'politeia-reading' ), $pages ) : __( 'Pages: —', 'politeia-reading' );
@@ -202,18 +203,22 @@ add_shortcode(
                                         </div>
                                 </div>
                                 <div class="prs-library__extras">
-                                        <div class="prs-library__progress">
-                                                <div
-                                                        class="prs-library__progress-track"
-                                                        role="progressbar"
-                                                        aria-valuenow="<?php echo esc_attr( $progress ); ?>"
-                                                        aria-valuemin="0"
-                                                        aria-valuemax="100"
-                                                        aria-valuetext="<?php echo esc_attr( $progress_label ); ?>"
-                                                >
-                                                        <div class="prs-library__progress-fill" style="width: <?php echo (int) $progress; ?>%;"></div>
+                                        <div class="prs-library__progress-field">
+                                                <span id="<?php echo esc_attr( $progress_id ); ?>" class="prs-library__progress-label"><?php esc_html_e( 'Reading Progress', 'politeia-reading' ); ?></span>
+                                                <div class="prs-library__progress">
+                                                        <div
+                                                                class="prs-library__progress-track"
+                                                                role="progressbar"
+                                                                aria-valuenow="<?php echo esc_attr( $progress ); ?>"
+                                                                aria-valuemin="0"
+                                                                aria-valuemax="100"
+                                                                aria-valuetext="<?php echo esc_attr( $progress_label ); ?>"
+                                                                aria-labelledby="<?php echo esc_attr( $progress_id ); ?>"
+                                                        >
+                                                                <div class="prs-library__progress-fill" style="width: <?php echo (int) $progress; ?>%;"></div>
+                                                        </div>
+                                                        <span class="prs-library__progress-value"><?php echo (int) $progress; ?>%</span>
                                                 </div>
-                                                <span class="prs-library__progress-value"><?php echo (int) $progress; ?>%</span>
                                         </div>
                                         <button type="button" class="prs-library__remove" aria-label="<?php esc_attr_e( 'Remove book', 'politeia-reading' ); ?>">
                                                 <?php esc_html_e( 'Remove', 'politeia-reading' ); ?>

--- a/modules/reading/shortcodes/my-books.php
+++ b/modules/reading/shortcodes/my-books.php
@@ -10,8 +10,20 @@ add_shortcode(
 			return '<p>' . esc_html__( 'You must be logged in to view your library.', 'politeia-reading' ) . '</p>';
 		}
 
-		wp_enqueue_style( 'politeia-reading' );
-		wp_enqueue_script( 'politeia-my-book' );
+                wp_enqueue_style( 'politeia-reading' );
+                wp_enqueue_script( 'politeia-my-book' );
+                wp_localize_script(
+                        'politeia-my-book',
+                        'PRS_LIBRARY',
+                        array(
+                                'ajax_url' => admin_url( 'admin-ajax.php' ),
+                                'messages' => array(
+                                        'invalid'   => __( 'Please enter a valid number of pages.', 'politeia-reading' ),
+                                        'too_small' => __( 'Please enter a number greater than zero.', 'politeia-reading' ),
+                                        'error'     => __( 'There was an error saving the number of pages.', 'politeia-reading' ),
+                                ),
+                        )
+                );
 
 		$user_id  = get_current_user_id();
 		$per_page = (int) apply_filters( 'politeia_my_books_per_page', 15 );
@@ -120,7 +132,9 @@ add_shortcode(
                                 $progress_id = 'reading-progress-' . (int) $r->user_book_id;
 
                                 $year_text  = $year ? sprintf( __( 'Published: %s', 'politeia-reading' ), $year ) : __( 'Published: —', 'politeia-reading' );
-                                $pages_text = $pages ? sprintf( __( 'Pages: %s', 'politeia-reading' ), $pages ) : __( 'Pages: —', 'politeia-reading' );
+                                $pages_value    = $pages ? (int) $pages : '';
+                                $pages_display  = $pages ? (string) (int) $pages : '';
+                                $pages_input_id = 'prs-pages-input-' . (int) $r->user_book_id;
 
                                 /* translators: %s: percentage of reading progress. */
                                 $progress_label = sprintf( __( '%s%% complete', 'politeia-reading' ), $progress );
@@ -153,7 +167,24 @@ add_shortcode(
                                                 <span class="prs-library__meta-item prs-library__author"><?php echo esc_html( $r->author ); ?></span>
                                                 <?php endif; ?>
                                                 <span class="prs-library__meta-item prs-library__year"><?php echo esc_html( $year_text ); ?></span>
-                                                <span class="prs-library__meta-item prs-library__pages"><?php echo esc_html( $pages_text ); ?></span>
+                                                <span class="prs-library__meta-item prs-library__pages" data-pages="<?php echo esc_attr( $pages_value ); ?>">
+                                                        <span class="prs-library__pages-display">
+                                                                <span class="prs-library__pages-label"><?php esc_html_e( 'Pages:', 'politeia-reading' ); ?></span>
+                                                                <span class="prs-library__pages-value"><?php echo esc_html( $pages_display ); ?></span>
+                                                                <button type="button" class="prs-library__pages-edit"><?php esc_html_e( 'Edit', 'politeia-reading' ); ?></button>
+                                                        </span>
+                                                        <input
+                                                                type="number"
+                                                                min="1"
+                                                                step="1"
+                                                                inputmode="numeric"
+                                                                class="prs-library__pages-input"
+                                                                id="<?php echo esc_attr( $pages_input_id ); ?>"
+                                                                value="<?php echo esc_attr( $pages_value ); ?>"
+                                                                aria-label="<?php esc_attr_e( 'Total pages', 'politeia-reading' ); ?>"
+                                                        />
+                                                        <span class="prs-library__pages-error" role="alert" aria-live="polite"></span>
+                                                </span>
                                         </div>
                                 </div>
                                 </td>

--- a/modules/reading/shortcodes/my-books.php
+++ b/modules/reading/shortcodes/my-books.php
@@ -55,9 +55,10 @@ add_shortcode(
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"
-        SELECT ub.id AS user_book_id,
-               ub.reading_status,
-               ub.owning_status,
+       SELECT ub.id AS user_book_id,
+              ub.reading_status,
+              ub.owning_status,
+              ub.pages,
                b.id   AS book_id,
                b.title,
                b.author,
@@ -93,93 +94,137 @@ add_shortcode(
 		);
 
 		ob_start(); ?>
-	<div class="prs-library">
-		<table class="prs-table">
-		<thead>
-			<tr>
-			<th><?php esc_html_e( 'Cover', 'politeia-reading' ); ?></th>
-			<th><?php esc_html_e( 'Title', 'politeia-reading' ); ?></th>
-			<th><?php esc_html_e( 'Author', 'politeia-reading' ); ?></th>
-			<th><?php esc_html_e( 'Year', 'politeia-reading' ); ?></th>
-			<th><?php esc_html_e( 'Reading Status', 'politeia-reading' ); ?></th>
-			<th><?php esc_html_e( 'Owning Status', 'politeia-reading' ); ?></th>
-			</tr>
-		</thead>
-		<tbody>
-			<?php foreach ( (array) $rows as $r ) : ?>
-			<tr data-user-book-id="<?php echo (int) $r->user_book_id; ?>">
-				<td style="width:60px">
-				<?php
-				if ( $r->cover_attachment_id ) {
-					echo wp_get_attachment_image(
-						(int) $r->cover_attachment_id,
-						'thumbnail',
-						false,
-						array(
-							'style' => 'max-width:50px;height:auto;border-radius:4px',
-							'alt'   => $r->title,
-						)
-					);
-				} else {
-					echo '<div style="width:50px;height:70px;background:#eee;border-radius:4px;"></div>';
-				}
-				?>
-				</td>
-				<td>
-				<?php
-					$slug = $r->slug ?: sanitize_title( $r->title . '-' . $r->author . ( $r->year ? '-' . $r->year : '' ) );
-					$url  = home_url( '/my-books/my-book-' . $slug );
-				?>
-				<a href="<?php echo esc_url( $url ); ?>">
-					<?php echo esc_html( $r->title ); ?>
-				</a>
-				</td>
-				<td><?php echo esc_html( $r->author ); ?></td>
-				<td><?php echo $r->year ? (int) $r->year : '—'; ?></td>
-				<td>
-				<select class="prs-reading-status">
-					<?php
-					$reading = array(
-						'not_started' => __( 'Not Started', 'politeia-reading' ),
-						'started'     => __( 'Started', 'politeia-reading' ),
-						'finished'    => __( 'Finished', 'politeia-reading' ),
-					);
-					foreach ( $reading as $val => $label ) {
-						printf(
-							'<option value="%s"%s>%s</option>',
-							esc_attr( $val ),
-							selected( $r->reading_status, $val, false ),
-							esc_html( $label )
-						);
-					}
-					?>
-				</select>
-				</td>
-				<td>
-				<select class="prs-owning-status">
-					<?php
-					$owning = array(
-						'in_shelf'  => __( 'In Shelf', 'politeia-reading' ),
-						'lost'      => __( 'Lost', 'politeia-reading' ),
-						'borrowed'  => __( 'Borrowed', 'politeia-reading' ),
-						'borrowing' => __( 'Borrowing', 'politeia-reading' ),
-						'sold'      => __( 'Sold', 'politeia-reading' ),
-					);
-					foreach ( $owning as $val => $label ) {
-						printf(
-							'<option value="%s"%s>%s</option>',
-							esc_attr( $val ),
-							selected( $r->owning_status, $val, false ),
-							esc_html( $label )
-						);
-					}
-					?>
-				</select>
-				</td>
-			</tr>
-			<?php endforeach; ?>
-		</tbody>
-		</table>
+        <div class="prs-library">
+                <table id="prs-library" class="prs-table">
+                <thead>
+                        <tr>
+                        <th scope="col"><?php esc_html_e( 'Book', 'politeia-reading' ); ?></th>
+                        <th scope="col"><?php esc_html_e( 'Status & Actions', 'politeia-reading' ); ?></th>
+                        </tr>
+                </thead>
+                <tbody>
+                        <?php foreach ( (array) $rows as $r ) :
+                                $slug     = $r->slug ?: sanitize_title( $r->title . '-' . $r->author . ( $r->year ? '-' . $r->year : '' ) );
+                                $url      = home_url( '/my-books/my-book-' . $slug );
+                                $year     = $r->year ? (int) $r->year : null;
+                                $pages    = $r->pages ? (int) $r->pages : null;
+                                $progress = 0;
+
+                                if ( 'finished' === $r->reading_status ) {
+                                        $progress = 100;
+                                } elseif ( 'started' === $r->reading_status ) {
+                                        $progress = 50;
+                                }
+
+                                $reading_id = 'reading-status-' . (int) $r->user_book_id;
+                                $owning_id  = 'owning-status-' . (int) $r->user_book_id;
+
+                                $year_text  = $year ? sprintf( __( 'Published: %s', 'politeia-reading' ), $year ) : __( 'Published: —', 'politeia-reading' );
+                                $pages_text = $pages ? sprintf( __( 'Pages: %s', 'politeia-reading' ), $pages ) : __( 'Pages: —', 'politeia-reading' );
+
+                                /* translators: %s: percentage of reading progress. */
+                                $progress_label = sprintf( __( '%s%% complete', 'politeia-reading' ), $progress );
+                                ?>
+                        <tr data-user-book-id="<?php echo (int) $r->user_book_id; ?>">
+                                <td class="prs-library__info">
+                                <div class="prs-library__cover">
+                                <?php
+                                if ( $r->cover_attachment_id ) {
+                                        echo wp_get_attachment_image(
+                                                (int) $r->cover_attachment_id,
+                                                'thumbnail',
+                                                false,
+                                                array(
+                                                        'class' => 'prs-library__cover-image',
+                                                        'alt'   => sanitize_text_field( $r->title ),
+                                                )
+                                        );
+                                } else {
+                                        echo '<div class="prs-library__cover-placeholder" aria-hidden="true"></div>';
+                                }
+                                ?>
+                                </div>
+                                <div class="prs-library__details">
+                                        <a class="prs-library__title" href="<?php echo esc_url( $url ); ?>">
+                                        <?php echo esc_html( $r->title ); ?>
+                                        </a>
+                                        <div class="prs-library__meta">
+                                                <?php if ( ! empty( $r->author ) ) : ?>
+                                                <span class="prs-library__meta-item prs-library__author"><?php echo esc_html( $r->author ); ?></span>
+                                                <?php endif; ?>
+                                                <span class="prs-library__meta-item prs-library__year"><?php echo esc_html( $year_text ); ?></span>
+                                                <span class="prs-library__meta-item prs-library__pages"><?php echo esc_html( $pages_text ); ?></span>
+                                        </div>
+                                </div>
+                                </td>
+                                <td class="prs-library__actions">
+                                <div class="prs-library__controls">
+                                        <div class="prs-library__field">
+                                                <label for="<?php echo esc_attr( $reading_id ); ?>"><?php esc_html_e( 'Reading Status', 'politeia-reading' ); ?></label>
+                                                <select id="<?php echo esc_attr( $reading_id ); ?>" class="prs-reading-status">
+                                                <?php
+                                                $reading = array(
+                                                        'not_started' => __( 'Not Started', 'politeia-reading' ),
+                                                        'started'     => __( 'Started', 'politeia-reading' ),
+                                                        'finished'    => __( 'Finished', 'politeia-reading' ),
+                                                );
+                                                foreach ( $reading as $val => $label ) {
+                                                        printf(
+                                                                '<option value="%s"%s>%s</option>',
+                                                                esc_attr( $val ),
+                                                                selected( $r->reading_status, $val, false ),
+                                                                esc_html( $label )
+                                                        );
+                                                }
+                                                ?>
+                                                </select>
+                                        </div>
+                                        <div class="prs-library__field">
+                                                <label for="<?php echo esc_attr( $owning_id ); ?>"><?php esc_html_e( 'Owning Status', 'politeia-reading' ); ?></label>
+                                                <select id="<?php echo esc_attr( $owning_id ); ?>" class="prs-owning-status">
+                                                <?php
+                                                $owning = array(
+                                                        'in_shelf'  => __( 'In Shelf', 'politeia-reading' ),
+                                                        'lost'      => __( 'Lost', 'politeia-reading' ),
+                                                        'borrowed'  => __( 'Borrowed', 'politeia-reading' ),
+                                                        'borrowing' => __( 'Borrowing', 'politeia-reading' ),
+                                                        'sold'      => __( 'Sold', 'politeia-reading' ),
+                                                );
+                                                foreach ( $owning as $val => $label ) {
+                                                        printf(
+                                                                '<option value="%s"%s>%s</option>',
+                                                                esc_attr( $val ),
+                                                                selected( $r->owning_status, $val, false ),
+                                                                esc_html( $label )
+                                                        );
+                                                }
+                                                ?>
+                                                </select>
+                                        </div>
+                                </div>
+                                <div class="prs-library__extras">
+                                        <div class="prs-library__progress">
+                                                <div
+                                                        class="prs-library__progress-track"
+                                                        role="progressbar"
+                                                        aria-valuenow="<?php echo esc_attr( $progress ); ?>"
+                                                        aria-valuemin="0"
+                                                        aria-valuemax="100"
+                                                        aria-valuetext="<?php echo esc_attr( $progress_label ); ?>"
+                                                >
+                                                        <div class="prs-library__progress-fill" style="width: <?php echo (int) $progress; ?>%;"></div>
+                                                </div>
+                                                <span class="prs-library__progress-value"><?php echo (int) $progress; ?>%</span>
+                                        </div>
+                                        <button type="button" class="prs-library__remove" aria-label="<?php esc_attr_e( 'Remove book', 'politeia-reading' ); ?>">
+                                                <span aria-hidden="true">&times;</span>
+                                        </button>
+                                </div>
+                                </td>
+                        </tr>
+                        <?php endforeach; ?>
+                </tbody>
+                </table>
 
 		<?php if ( ! empty( $paginate ) ) : ?>
 		<nav class="prs-pagination" aria-label="<?php esc_attr_e( 'Library pagination', 'politeia-reading' ); ?>">


### PR DESCRIPTION
## Summary
- give the My Library table a dedicated id and split each row into book information and actions
- surface optional metadata, placeholder progress, and a remove control within the library rows
- style the redesigned layout with a 33/66 structure, responsive behavior, and visual affordances for the new elements

## Testing
- `vendor/bin/phpcs modules/reading/shortcodes/my-books.php` *(fails: repository does not follow WPCS formatting, producing numerous pre-existing violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cf11df19988332856a18a52d2665ef