### PR TITLE
Add centered modal layout for add book form

### DIFF
--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -296,6 +296,7 @@ table.prs-form__table {
 .prs-form__label-text {
         font-weight: 600;
         color: #333;
+        display: block;
 }
 
 .prs-form__label-note {
@@ -303,6 +304,7 @@ table.prs-form__table {
         line-height: 1.2;
         color: #6b7280;
         font-weight: 500;
+        display: block;
 }
 
 .prs-form__table input[type="text"],
@@ -325,6 +327,7 @@ table.prs-form__table {
         position: relative;
         display: flex;
         align-items: center;
+        justify-content: center;
         gap: 16px;
         flex-wrap: wrap;
 }
@@ -395,8 +398,8 @@ table.prs-form__table {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: 80px;
-        height: 80px;
+        width: 60px;
+        height: 60px;
         border-radius: 8px;
         background: #f3f4f6;
         border: 1px dashed #cbd5f5;

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -198,6 +198,124 @@
         letter-spacing: 0.02em;
 }
 
+.prs-add-book {
+        position: relative;
+}
+
+.prs-add-book__modal {
+        position: fixed;
+        inset: 0;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background: rgba(0, 0, 0, 0.45);
+        z-index: 9999;
+}
+
+.prs-add-book__modal-content {
+        position: relative;
+        width: 100%;
+        max-width: 520px;
+        background: #fff;
+        border-radius: 12px;
+        padding: 32px 36px 28px;
+        box-shadow: 0 18px 45px rgba(17, 24, 39, 0.25);
+}
+
+.prs-add-book__heading {
+        margin-top: 0;
+        margin-bottom: 20px;
+        font-size: 1.4rem;
+        font-weight: 600;
+        text-align: center;
+        color: #111;
+}
+
+.prs-add-book__close {
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: 50%;
+        background: transparent;
+        color: #555;
+        font-size: 1.6rem;
+        line-height: 1;
+        cursor: pointer;
+        transition: background 0.2s ease, color 0.2s ease;
+}
+
+.prs-add-book__close:hover,
+.prs-add-book__close:focus {
+        background: rgba(0, 0, 0, 0.05);
+        color: #111;
+        outline: none;
+}
+
+#prs-add-book-form {
+        width: 100%;
+}
+
+.prs-form__table {
+        width: 100%;
+        border-collapse: collapse;
+}
+
+.prs-form__table th,
+.prs-form__table td {
+        padding: 12px 0;
+        vertical-align: middle;
+}
+
+.prs-form__table th {
+        width: 35%;
+        padding-right: 20px;
+        text-align: left;
+        font-weight: 600;
+        color: #333;
+}
+
+.prs-form__table td {
+        width: 65%;
+}
+
+.prs-form__table input[type="text"],
+.prs-form__table input[type="number"],
+.prs-form__table input[type="file"] {
+        width: 100%;
+        padding: 10px 12px;
+        border: 1px solid #d0d0d0;
+        border-radius: 6px;
+        font-size: 0.95rem;
+        color: #333;
+        background-color: #fff;
+}
+
+.prs-form__table input[type="file"] {
+        padding: 6px 0;
+}
+
+.prs-form__table input[type="text"]:focus,
+.prs-form__table input[type="number"]:focus,
+.prs-form__table input[type="file"]:focus {
+        outline: 2px solid #0073aa;
+        outline-offset: 1px;
+}
+
+.prs-form__required {
+        margin-left: 4px;
+        color: #d93025;
+        font-weight: 700;
+}
+
+.prs-form__actions td {
+        text-align: center;
+        padding-top: 22px;
+}
+
 #prs-library select.prs-reading-status,
 #prs-library select.prs-owning-status {
         min-width: 170px;

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -293,6 +293,11 @@ table.prs-form__table {
         gap: 4px;
 }
 
+.prs-form__label-text {
+        font-weight: 600;
+        color: #333;
+}
+
 .prs-form__label-note {
         font-size: 10px;
         line-height: 1.2;
@@ -320,7 +325,7 @@ table.prs-form__table {
         position: relative;
         display: flex;
         align-items: center;
-        gap: 14px;
+        gap: 16px;
         flex-wrap: wrap;
 }
 
@@ -386,10 +391,23 @@ table.prs-form__table {
         white-space: nowrap;
 }
 
-.prs-form__file-filename {
-        font-size: 0.85rem;
-        color: #4b5563;
-        word-break: break-word;
+.prs-form__file-preview {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 80px;
+        height: 80px;
+        border-radius: 8px;
+        background: #f3f4f6;
+        border: 1px dashed #cbd5f5;
+        overflow: hidden;
+}
+
+.prs-form__file-preview img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
 }
 
 .prs-form__table input[type="text"]:focus,
@@ -406,7 +424,7 @@ table.prs-form__table {
 }
 
 .prs-form__actions td {
-        text-align: center;
+        text-align: right;
         padding-top: 22px;
 }
 

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -266,6 +266,7 @@
 
 table.prs-form__table {
         border: none;
+        margin-bottom: 0;
 }
 
 .prs-form__table th,

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -264,6 +264,10 @@
         border-collapse: collapse;
 }
 
+table.prs-form__table {
+        border: none;
+}
+
 .prs-form__table th,
 .prs-form__table td {
         padding: 12px 0;
@@ -282,6 +286,20 @@
         width: 65%;
 }
 
+.prs-form__label {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+}
+
+.prs-form__label-note {
+        font-size: 10px;
+        line-height: 1.2;
+        color: #6b7280;
+        font-weight: 500;
+}
+
 .prs-form__table input[type="text"],
 .prs-form__table input[type="number"],
 .prs-form__table input[type="file"] {
@@ -296,6 +314,82 @@
 
 .prs-form__table input[type="file"] {
         padding: 6px 0;
+}
+
+.prs-form__file-control {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        flex-wrap: wrap;
+}
+
+.prs-form__file-input {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        clip-path: inset(100%);
+        white-space: nowrap;
+        border: 0;
+}
+
+.prs-form__file-trigger {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        padding: 12px 20px;
+        border: none;
+        border-radius: 6px;
+        background: #8ccfec;
+        color: #fff;
+        font-size: 0.95rem;
+        font-weight: 600;
+        line-height: 1;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+        box-shadow: 0 6px 16px rgba(140, 207, 236, 0.35);
+}
+
+.prs-form__file-trigger:hover,
+.prs-form__file-trigger:focus {
+        background: #7dc8ea;
+        box-shadow: 0 10px 18px rgba(125, 200, 234, 0.45);
+        outline: none;
+}
+
+.prs-form__file-trigger:focus-visible {
+        outline: 3px solid rgba(59, 130, 246, 0.45);
+        outline-offset: 2px;
+}
+
+.prs-form__file-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.28);
+        font-size: 0.85rem;
+        font-weight: 700;
+}
+
+.prs-form__file-icon::before {
+        content: '\2191';
+}
+
+.prs-form__file-text {
+        white-space: nowrap;
+}
+
+.prs-form__file-filename {
+        font-size: 0.85rem;
+        color: #4b5563;
+        word-break: break-word;
 }
 
 .prs-form__table input[type="text"]:focus,

--- a/modules/reading/shortcodes/add-book.php
+++ b/modules/reading/shortcodes/add-book.php
@@ -99,8 +99,8 @@ add_shortcode(
 							</tr>
 							<tr>
 								<th scope="row">
-									<label class="prs-form__label" for="prs_cover">
-										<span class="prs-form__label-text"><?php esc_html_e( 'Cover', 'politeia-reading' ); ?></span>
+                                                                        <label class="prs-form__label" for="prs_cover">
+                                                                                <span class="prs-form__label-text"><?php esc_html_e( 'Cover', 'politeia-reading' ); ?>:</span>
 										<span class="prs-form__label-note"><?php esc_html_e( '(jpg/png/webp)', 'politeia-reading' ); ?></span>
 									</label>
 								</th>
@@ -153,17 +153,17 @@ add_shortcode(
 								var changeLabel = trigger ? trigger.getAttribute('data-change-label') : '';
 								var form = fileInput.form;
 
-								var resetPreview = function () {
-									if (previewWrapper) {
-										previewWrapper.setAttribute('hidden', 'hidden');
-									}
-									if (previewImage) {
-										previewImage.removeAttribute('src');
-									}
-									if (triggerText && defaultLabel) {
-										triggerText.textContent = defaultLabel;
-									}
-								};
+                                                                        var resetPreview = function () {
+                                                                                if (previewWrapper) {
+                                                                                        previewWrapper.hidden = true;
+                                                                                }
+                                                                                if (previewImage) {
+                                                                                        previewImage.removeAttribute('src');
+                                                                                }
+                                                                                if (triggerText && defaultLabel) {
+                                                                                        triggerText.textContent = defaultLabel;
+                                                                                }
+                                                                        };
 
 								if (form) {
 									form.addEventListener('reset', function () {
@@ -177,7 +177,7 @@ add_shortcode(
 										reader.onload = function (event) {
 											if (previewWrapper && previewImage) {
 												previewImage.src = event.target && event.target.result ? event.target.result : '';
-												previewWrapper.removeAttribute('hidden');
+                                                                                                previewWrapper.hidden = false;
 											}
 										};
 										reader.readAsDataURL(this.files[0]);

--- a/modules/reading/shortcodes/add-book.php
+++ b/modules/reading/shortcodes/add-book.php
@@ -97,14 +97,35 @@ add_shortcode(
 										max="<?php echo esc_attr( (int) date( 'Y' ) + 1 ); ?>" />
 								</td>
 							</tr>
-							<tr>
-								<th scope="row">
-									<label for="prs_cover"><?php esc_html_e( 'Cover (jpg/png/webp)', 'politeia-reading' ); ?></label>
-								</th>
-								<td>
-									<input type="file" id="prs_cover" name="prs_cover" accept=".jpg,.jpeg,.png,.webp" />
-								</td>
-							</tr>
+                                                        <tr>
+                                                                <th scope="row">
+                                                                        <label class="prs-form__label" for="prs_cover">
+                                                                                <?php esc_html_e( 'Cover', 'politeia-reading' ); ?>
+                                                                                <span class="prs-form__label-note"><?php esc_html_e( '(jpg/png/webp)', 'politeia-reading' ); ?></span>
+                                                                        </label>
+                                                                </th>
+                                                                <td>
+                                                                        <div class="prs-form__file-control">
+                                                                                <input
+                                                                                        type="file"
+                                                                                        id="prs_cover"
+                                                                                        name="prs_cover"
+                                                                                        accept=".jpg,.jpeg,.png,.webp"
+                                                                                        class="prs-form__file-input"
+                                                                                        onchange="document.getElementById('prs_cover_filename').textContent = this.files.length ? this.files[0].name : '<?php echo esc_js( __( 'No file selected', 'politeia-reading' ) ); ?>';"
+                                                                                />
+                                                                                <button
+                                                                                        type="button"
+                                                                                        class="prs-form__file-trigger"
+                                                                                        onclick="document.getElementById('prs_cover').click();"
+                                                                                >
+                                                                                        <span class="prs-form__file-icon" aria-hidden="true"></span>
+                                                                                        <span class="prs-form__file-text"><?php esc_html_e( 'Upload Book Cover', 'politeia-reading' ); ?></span>
+                                                                                </button>
+                                                                                <span id="prs_cover_filename" class="prs-form__file-filename" aria-live="polite"><?php esc_html_e( 'No file selected', 'politeia-reading' ); ?></span>
+                                                                        </div>
+                                                                </td>
+                                                        </tr>
 							<tr class="prs-form__actions">
 								<td colspan="2">
 									<button class="prs-btn" type="submit"><?php esc_html_e( 'Save to My Library', 'politeia-reading' ); ?></button>

--- a/modules/reading/shortcodes/add-book.php
+++ b/modules/reading/shortcodes/add-book.php
@@ -97,46 +97,104 @@ add_shortcode(
 										max="<?php echo esc_attr( (int) date( 'Y' ) + 1 ); ?>" />
 								</td>
 							</tr>
-                                                        <tr>
-                                                                <th scope="row">
-                                                                        <label class="prs-form__label" for="prs_cover">
-                                                                                <?php esc_html_e( 'Cover', 'politeia-reading' ); ?>
-                                                                                <span class="prs-form__label-note"><?php esc_html_e( '(jpg/png/webp)', 'politeia-reading' ); ?></span>
-                                                                        </label>
-                                                                </th>
-                                                                <td>
-                                                                        <div class="prs-form__file-control">
-                                                                                <input
-                                                                                        type="file"
-                                                                                        id="prs_cover"
-                                                                                        name="prs_cover"
-                                                                                        accept=".jpg,.jpeg,.png,.webp"
-                                                                                        class="prs-form__file-input"
-                                                                                        onchange="document.getElementById('prs_cover_filename').textContent = this.files.length ? this.files[0].name : '<?php echo esc_js( __( 'No file selected', 'politeia-reading' ) ); ?>';"
-                                                                                />
-                                                                                <button
-                                                                                        type="button"
-                                                                                        class="prs-form__file-trigger"
-                                                                                        onclick="document.getElementById('prs_cover').click();"
-                                                                                >
-                                                                                        <span class="prs-form__file-icon" aria-hidden="true"></span>
-                                                                                        <span class="prs-form__file-text"><?php esc_html_e( 'Upload Book Cover', 'politeia-reading' ); ?></span>
-                                                                                </button>
-                                                                                <span id="prs_cover_filename" class="prs-form__file-filename" aria-live="polite"><?php esc_html_e( 'No file selected', 'politeia-reading' ); ?></span>
-                                                                        </div>
-                                                                </td>
-                                                        </tr>
+							<tr>
+								<th scope="row">
+									<label class="prs-form__label" for="prs_cover">
+										<span class="prs-form__label-text"><?php esc_html_e( 'Cover', 'politeia-reading' ); ?></span>
+										<span class="prs-form__label-note"><?php esc_html_e( '(jpg/png/webp)', 'politeia-reading' ); ?></span>
+									</label>
+								</th>
+								<td>
+									<div class="prs-form__file-control">
+										<input
+											type="file"
+											id="prs_cover"
+											name="prs_cover"
+											accept=".jpg,.jpeg,.png,.webp"
+											class="prs-form__file-input"
+										/>
+										<button
+											type="button"
+											id="prs_cover_trigger"
+											class="prs-form__file-trigger"
+											data-default-label="<?php echo esc_attr__( 'Upload Book Cover', 'politeia-reading' ); ?>"
+											data-change-label="<?php echo esc_attr__( 'Change Book Cover', 'politeia-reading' ); ?>"
+											onclick="document.getElementById('prs_cover').click();"
+										>
+											<span class="prs-form__file-icon" aria-hidden="true"></span>
+											<span class="prs-form__file-text"><?php esc_html_e( 'Upload Book Cover', 'politeia-reading' ); ?></span>
+										</button>
+										<div id="prs_cover_preview" class="prs-form__file-preview" hidden>
+											<img src="" alt="<?php echo esc_attr__( 'Selected book cover preview', 'politeia-reading' ); ?>" />
+										</div>
+									</div>
+								</td>
+							</tr>
 							<tr class="prs-form__actions">
 								<td colspan="2">
 									<button class="prs-btn" type="submit"><?php esc_html_e( 'Save to My Library', 'politeia-reading' ); ?></button>
 								</td>
 							</tr>
 						</tbody>
-					</table>
-				</form>
-			</div>
+						</table>
+						</form>
+						<script>
+							( function () {
+								var fileInput = document.getElementById('prs_cover');
+								if (!fileInput) {
+									return;
+								}
+
+								var trigger = document.getElementById('prs_cover_trigger');
+								var triggerText = trigger ? trigger.querySelector('.prs-form__file-text') : null;
+								var previewWrapper = document.getElementById('prs_cover_preview');
+								var previewImage = previewWrapper ? previewWrapper.querySelector('img') : null;
+								var defaultLabel = trigger ? trigger.getAttribute('data-default-label') : '';
+								var changeLabel = trigger ? trigger.getAttribute('data-change-label') : '';
+								var form = fileInput.form;
+
+								var resetPreview = function () {
+									if (previewWrapper) {
+										previewWrapper.setAttribute('hidden', 'hidden');
+									}
+									if (previewImage) {
+										previewImage.removeAttribute('src');
+									}
+									if (triggerText && defaultLabel) {
+										triggerText.textContent = defaultLabel;
+									}
+								};
+
+								if (form) {
+									form.addEventListener('reset', function () {
+										window.setTimeout(resetPreview);
+									});
+								}
+
+								fileInput.addEventListener('change', function () {
+									if (this.files && this.files[0]) {
+										var reader = new FileReader();
+										reader.onload = function (event) {
+											if (previewWrapper && previewImage) {
+												previewImage.src = event.target && event.target.result ? event.target.result : '';
+												previewWrapper.removeAttribute('hidden');
+											}
+										};
+										reader.readAsDataURL(this.files[0]);
+										if (triggerText && changeLabel) {
+											triggerText.textContent = changeLabel;
+										}
+									} else {
+										resetPreview();
+									}
+								});
+
+								resetPreview();
+							}() );
+						</script>
+						</div>
+				</div>
 		</div>
-	</div>
 		<?php
 		return ob_get_clean();
 	}

--- a/modules/reading/shortcodes/add-book.php
+++ b/modules/reading/shortcodes/add-book.php
@@ -28,40 +28,93 @@ add_shortcode(
 		}
 		?>
 	<div class="prs-add-book">
-		<button type="button" class="prs-btn" onclick="document.getElementById('prs-add-book-form').style.display='block'">
+		<button
+			type="button"
+			class="prs-btn"
+			aria-controls="prs-add-book-modal"
+			onclick="document.getElementById('prs-add-book-modal').style.display='flex'">
 			<?php echo esc_html__( 'Add Book', 'politeia-reading' ); ?>
 		</button>
 
-		<form id="prs-add-book-form"
-				class="prs-form"
-				method="post"
-				enctype="multipart/form-data"
-				action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>"
-				style="display:none;">
-			<?php wp_nonce_field( 'prs_add_book', 'prs_nonce' ); ?>
-			<input type="hidden" name="action" value="prs_add_book_submit" />
+		<div id="prs-add-book-modal"
+			class="prs-add-book__modal"
+			style="display:none;"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="prs-add-book-form-title"
+			onclick="this.style.display='none'">
+			<div class="prs-add-book__modal-content" onclick="event.stopPropagation();">
+				<button type="button"
+					class="prs-add-book__close"
+					aria-label="<?php echo esc_attr__( 'Close dialog', 'politeia-reading' ); ?>"
+					onclick="document.getElementById('prs-add-book-modal').style.display='none'">
+					&times;
+				</button>
+				<form id="prs-add-book-form"
+					class="prs-form"
+					method="post"
+					enctype="multipart/form-data"
+					action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<h2 id="prs-add-book-form-title" class="prs-add-book__heading">
+						<?php echo esc_html__( 'Add Book', 'politeia-reading' ); ?>
+					</h2>
+					<?php wp_nonce_field( 'prs_add_book', 'prs_nonce' ); ?>
+					<input type="hidden" name="action" value="prs_add_book_submit" />
 
-			<label><?php _e( 'Title', 'politeia-reading' ); ?>*
-				<input type="text" name="prs_title" required />
-			</label>
-
-			<label><?php _e( 'Author', 'politeia-reading' ); ?>*
-				<input type="text" name="prs_author" required />
-			</label>
-
-			<label><?php _e( 'Year', 'politeia-reading' ); ?>
-				<input type="number"
-						name="prs_year"
-						min="1400"
-						max="<?php echo esc_attr( (int) date( 'Y' ) + 1 ); ?>" />
-			</label>
-
-			<label><?php _e( 'Cover (jpg/png/webp)', 'politeia-reading' ); ?>
-				<input type="file" name="prs_cover" accept=".jpg,.jpeg,.png,.webp" />
-			</label>
-
-			<button class="prs-btn" type="submit"><?php _e( 'Save to My Library', 'politeia-reading' ); ?></button>
-		</form>
+					<table class="prs-form__table">
+						<tbody>
+							<tr>
+								<th scope="row">
+									<label for="prs_title">
+										<?php esc_html_e( 'Title', 'politeia-reading' ); ?>
+										<span class="prs-form__required" aria-hidden="true">*</span>
+									</label>
+								</th>
+								<td>
+									<input type="text" id="prs_title" name="prs_title" required />
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<label for="prs_author">
+										<?php esc_html_e( 'Author', 'politeia-reading' ); ?>
+										<span class="prs-form__required" aria-hidden="true">*</span>
+									</label>
+								</th>
+								<td>
+									<input type="text" id="prs_author" name="prs_author" required />
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<label for="prs_year"><?php esc_html_e( 'Year', 'politeia-reading' ); ?></label>
+								</th>
+								<td>
+									<input type="number"
+										id="prs_year"
+										name="prs_year"
+										min="1400"
+										max="<?php echo esc_attr( (int) date( 'Y' ) + 1 ); ?>" />
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									<label for="prs_cover"><?php esc_html_e( 'Cover (jpg/png/webp)', 'politeia-reading' ); ?></label>
+								</th>
+								<td>
+									<input type="file" id="prs_cover" name="prs_cover" accept=".jpg,.jpeg,.png,.webp" />
+								</td>
+							</tr>
+							<tr class="prs-form__actions">
+								<td colspan="2">
+									<button class="prs-btn" type="submit"><?php esc_html_e( 'Save to My Library', 'politeia-reading' ); ?></button>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</form>
+			</div>
+		</div>
 	</div>
 		<?php
 		return ob_get_clean();


### PR DESCRIPTION
## Summary
- convert the Add Book shortcode form into a modal overlay that opens from the trigger button and includes a close control
- reorganize the form fields into a table with proper labels and IDs for a balanced layout
- style the modal, table, and controls to center the popup and align inputs consistently

## Testing
- vendor/bin/phpcs --standard=modules/reading/phpcs.xml.dist modules/reading/shortcodes/add-book.php *(fails: existing coding standard issues in legacy code)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe612976c83329bbd226bebfc8f02