### PR TITLE
Add autocomplete for add book title field

### DIFF
--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -352,6 +352,50 @@ table.prs-form__table {
         background-color: #fff;
 }
 
+.prs-add-book__field {
+        position: relative;
+}
+
+.prs-add-book__suggestions {
+        position: absolute;
+        top: calc(100% + 4px);
+        left: 0;
+        right: 0;
+        display: none;
+        flex-direction: column;
+        background: #fff;
+        border: 1px solid #d0d0d0;
+        border-radius: 6px;
+        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+        max-height: 260px;
+        overflow-y: auto;
+        z-index: 25;
+        padding: 4px 0;
+}
+
+.prs-add-book__suggestions.is-visible {
+        display: flex;
+}
+
+.prs-add-book__suggestion {
+        width: 100%;
+        padding: 10px 14px;
+        background: transparent;
+        border: none;
+        text-align: left;
+        font-size: 0.95rem;
+        line-height: 1.35;
+        color: #1f2937;
+        cursor: pointer;
+        white-space: normal;
+}
+
+.prs-add-book__suggestion:hover,
+.prs-add-book__suggestion:focus {
+        background: #f3f4f6;
+        outline: none;
+}
+
 .prs-form__table input[type="file"] {
         padding: 6px 0;
 }

--- a/modules/reading/shortcodes/add-book.php
+++ b/modules/reading/shortcodes/add-book.php
@@ -80,10 +80,18 @@ add_shortcode(
 										<span class="prs-form__required" aria-hidden="true">*</span>
 									</label>
 								</th>
-								<td>
-									<input type="text" id="prs_title" name="prs_title" list="prs_title_suggestions" required />
-									<datalist id="prs_title_suggestions"></datalist>
-								</td>
+                                                                <td>
+                                                                        <div class="prs-add-book__field prs-add-book__field--title">
+                                                                                <input type="text" id="prs_title" name="prs_title" autocomplete="off" required />
+                                                                                <div
+                                                                                        id="prs_title_suggestions"
+                                                                                        class="prs-add-book__suggestions"
+                                                                                        role="listbox"
+                                                                                        aria-label="<?php esc_attr_e( 'Book suggestions', 'politeia-reading' ); ?>"
+                                                                                        aria-hidden="true"
+                                                                                ></div>
+                                                                        </div>
+                                                                </td>
 							</tr>
 							<tr>
 								<th scope="row">


### PR DESCRIPTION
## Summary
- enqueue the add-book script for the shortcode and add a datalist hook to the title input
- implement Open Library powered autocomplete that populates title suggestions and fills author/year when a suggestion is chosen

## Testing
- vendor/bin/phpcs modules/reading/shortcodes/add-book.php *(fails: existing coding standard violations in file)*

------
https://chatgpt.com/codex/tasks/task_e_68d0243e59948332b1d6950dcabb74e4