### PR TITLE
Show success details in add book modal

### DIFF
--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -244,11 +244,15 @@
 
 .prs-add-book__success {
         width: 100%;
-        display: flex;
+        display: none;
         flex-direction: column;
         align-items: center;
         justify-content: center;
         gap: 20px;
+}
+
+.prs-add-book__modal-content--success .prs-add-book__success {
+        display: flex;
 }
 
 .prs-add-book__success-heading {

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -276,17 +276,29 @@
 }
 
 .prs-add-book__success-label {
-        font-size: 0.95rem;
+        font-size: 0.6rem;
         font-weight: 600;
         color: #4b5563;
         text-transform: uppercase;
-        letter-spacing: 0.04em;
+        letter-spacing: 0.44em;
 }
 
 .prs-add-book__success-value {
         font-size: 1.15rem;
         font-weight: 600;
         color: #111827;
+}
+
+.prs-add-book__success-cover {
+        display: flex;
+        justify-content: center;
+}
+
+.prs-add-book__success-cover img {
+        display: block;
+        max-height: 100px;
+        width: auto;
+        height: auto;
 }
 
 .prs-add-book__mode-switch {

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -223,6 +223,16 @@
         box-shadow: 0 18px 45px rgba(17, 24, 39, 0.25);
 }
 
+.prs-add-book__modal-content--success {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        text-align: center;
+        min-height: 320px;
+        padding: 56px 48px;
+}
+
 .prs-add-book__heading {
         margin-top: 0;
         margin-bottom: 20px;
@@ -230,6 +240,53 @@
         font-weight: 600;
         text-align: center;
         color: #111;
+}
+
+.prs-add-book__success {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 20px;
+}
+
+.prs-add-book__success-heading {
+        margin: 0;
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: #111;
+}
+
+.prs-add-book__success-details {
+        width: 100%;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+}
+
+.prs-add-book__success-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+}
+
+.prs-add-book__success-label {
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: #4b5563;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+}
+
+.prs-add-book__success-value {
+        font-size: 1.15rem;
+        font-weight: 600;
+        color: #111827;
 }
 
 .prs-add-book__mode-switch {

--- a/modules/reading/assets/js/add-book.js
+++ b/modules/reading/assets/js/add-book.js
@@ -45,8 +45,8 @@
                 }
         };
 
-        var resetToForm = function () {
-                if (!successActive) {
+        var resetToForm = function (force) {
+                if (!successActive && !force) {
                         return;
                 }
 
@@ -113,6 +113,15 @@
                                 resetToForm();
                         }
                 });
+        }
+
+        var openButtons = document.querySelectorAll('[aria-controls="prs-add-book-modal"]');
+        if (openButtons && openButtons.length) {
+                for (var i = 0; i < openButtons.length; i++) {
+                        openButtons[i].addEventListener('click', function () {
+                                resetToForm(true);
+                        });
+                }
         }
 
         activateSuccess();

--- a/modules/reading/assets/js/add-book.js
+++ b/modules/reading/assets/js/add-book.js
@@ -26,7 +26,7 @@
                         var currentUrl = new window.URL(window.location.href);
                         var params = currentUrl.searchParams;
                         var removed = false;
-                        var keys = ['prs_added', 'prs_added_title', 'prs_added_author', 'prs_added_year', 'prs_added_pages'];
+                        var keys = ['prs_added', 'prs_added_title', 'prs_added_author', 'prs_added_year', 'prs_added_pages', 'prs_added_cover'];
 
                         for (var i = 0; i < keys.length; i++) {
                                 if (params.has(keys[i])) {

--- a/modules/reading/assets/js/add-book.js
+++ b/modules/reading/assets/js/add-book.js
@@ -1,4 +1,122 @@
 (function () {
+        var modal = document.getElementById('prs-add-book-modal');
+        var modalContent = modal ? modal.querySelector('.prs-add-book__modal-content') : null;
+        var form = document.getElementById('prs-add-book-form');
+        var formHeading = document.getElementById('prs-add-book-form-title');
+        var successContainer = document.getElementById('prs-add-book-success');
+        var successHeading = successContainer ? successContainer.querySelector('.prs-add-book__success-heading') : null;
+        var closeButton = modal ? modal.querySelector('.prs-add-book__close') : null;
+        var successActive = false;
+
+        var updateAriaLabelledBy = function (id) {
+                if (!modal) {
+                        return;
+                }
+                if (id) {
+                        modal.setAttribute('aria-labelledby', id);
+                }
+        };
+
+        var clearSuccessParams = function () {
+                if (typeof window === 'undefined' || !window.history || typeof window.URL !== 'function') {
+                        return;
+                }
+
+                try {
+                        var currentUrl = new window.URL(window.location.href);
+                        var params = currentUrl.searchParams;
+                        var removed = false;
+                        var keys = ['prs_added', 'prs_added_title', 'prs_added_author', 'prs_added_year', 'prs_added_pages'];
+
+                        for (var i = 0; i < keys.length; i++) {
+                                if (params.has(keys[i])) {
+                                        params.delete(keys[i]);
+                                        removed = true;
+                                }
+                        }
+
+                        if (removed) {
+                                var newSearch = params.toString();
+                                var newUrl = currentUrl.pathname + (newSearch ? '?' + newSearch : '') + currentUrl.hash;
+                                window.history.replaceState({}, '', newUrl);
+                        }
+                } catch (error) {
+                        // Fallback silently if URL API is unavailable.
+                }
+        };
+
+        var resetToForm = function () {
+                if (!successActive) {
+                        return;
+                }
+
+                successActive = false;
+
+                if (successContainer) {
+                        successContainer.hidden = true;
+                }
+
+                if (modalContent) {
+                        modalContent.classList.remove('prs-add-book__modal-content--success');
+                }
+
+                if (form) {
+                        form.hidden = false;
+                }
+
+                if (formHeading) {
+                        formHeading.hidden = false;
+                        updateAriaLabelledBy(formHeading.id);
+                }
+        };
+
+        var activateSuccess = function () {
+                if (!modal || !successContainer) {
+                        return;
+                }
+
+                if (modal.getAttribute('data-success') !== '1') {
+                        return;
+                }
+
+                successActive = true;
+                successContainer.hidden = false;
+
+                if (modalContent) {
+                        modalContent.classList.add('prs-add-book__modal-content--success');
+                }
+
+                if (form) {
+                        form.hidden = true;
+                }
+
+                if (formHeading) {
+                        formHeading.hidden = true;
+                }
+
+                if (successHeading && successHeading.id) {
+                        updateAriaLabelledBy(successHeading.id);
+                }
+
+                modal.style.display = 'flex';
+                clearSuccessParams();
+                modal.setAttribute('data-success', '0');
+        };
+
+        if (closeButton) {
+                closeButton.addEventListener('click', resetToForm);
+        }
+
+        if (modal) {
+                modal.addEventListener('click', function (event) {
+                        if (event.target === modal) {
+                                resetToForm();
+                        }
+                });
+        }
+
+        activateSuccess();
+
         var titleInput = document.getElementById('prs_title');
         if (!titleInput) {
                 return;

--- a/modules/reading/shortcodes/add-book.php
+++ b/modules/reading/shortcodes/add-book.php
@@ -53,17 +53,11 @@ add_shortcode(
 
 		ob_start();
 
-		// Avisos dentro del buffer del shortcode
-		if ( $success ) {
-			echo '<div class="prs-notice prs-notice--success">' .
-			esc_html__( 'Book added to My Library.', 'politeia-reading' ) .
-			'</div>';
-		}
-		if ( ! empty( $_GET['prs_error'] ) && $_GET['prs_error'] === '1' ) {
-			echo '<div class="prs-notice prs-notice--error">' .
-			esc_html__( 'There was a problem adding the book.', 'politeia-reading' ) .
-			'</div>';
-		}
+                if ( ! empty( $_GET['prs_error'] ) && $_GET['prs_error'] === '1' ) {
+                        echo '<div class="prs-notice prs-notice--error">' .
+                        esc_html__( 'There was a problem adding the book.', 'politeia-reading' ) .
+                        '</div>';
+                }
 		?>
 	<div class="prs-add-book">
 		<button

--- a/modules/reading/shortcodes/add-book.php
+++ b/modules/reading/shortcodes/add-book.php
@@ -14,11 +14,12 @@ add_shortcode(
 		wp_enqueue_style( 'politeia-reading' );
 		wp_enqueue_script( 'politeia-add-book' );
 
-		$success        = ! empty( $_GET['prs_added'] ) && '1' === $_GET['prs_added'];
-		$success_title  = '';
-		$success_author = '';
-		$success_year   = null;
-		$success_pages  = null;
+		$success           = ! empty( $_GET['prs_added'] ) && '1' === $_GET['prs_added'];
+		$success_title     = '';
+		$success_author    = '';
+		$success_year      = null;
+		$success_pages     = null;
+		$success_cover_url = '';
 
 		if ( $success ) {
 			if ( isset( $_GET['prs_added_title'] ) ) {
@@ -37,6 +38,15 @@ add_shortcode(
 				$pages = absint( $_GET['prs_added_pages'] );
 				if ( $pages > 0 ) {
 					$success_pages = $pages;
+				}
+			}
+			if ( isset( $_GET['prs_added_cover'] ) && '' !== $_GET['prs_added_cover'] ) {
+				$cover_id = absint( $_GET['prs_added_cover'] );
+				if ( $cover_id ) {
+					$cover_url = wp_get_attachment_image_url( $cover_id, 'medium' );
+					if ( $cover_url ) {
+						$success_cover_url = $cover_url;
+					}
 				}
 			}
 		}
@@ -80,6 +90,23 @@ add_shortcode(
 					&times;
 				</button>
 				<div id="prs-add-book-success" class="prs-add-book__success"<?php echo $success ? '' : ' hidden'; ?>>
+					<?php if ( $success_cover_url ) : ?>
+						<?php
+						$success_cover_alt = $success_title
+							? sprintf(
+								/* translators: %s: book title. */
+								__( 'Cover image for %s', 'politeia-reading' ),
+								$success_title
+							)
+							: __( 'Uploaded book cover image', 'politeia-reading' );
+						?>
+						<div class="prs-add-book__success-cover">
+							<img src="<?php echo esc_url( $success_cover_url ); ?>"
+								alt="<?php echo esc_attr( $success_cover_alt ); ?>"
+								loading="lazy"
+								decoding="async" />
+						</div>
+					<?php endif; ?>
 					<h2 id="prs-add-book-success-title" class="prs-add-book__success-heading">
 						<?php echo esc_html__( 'Book Added Successfully', 'politeia-reading' ); ?>
 					</h2>
@@ -384,6 +411,10 @@ function prs_add_book_submit_handler() {
 
 	if ( null !== $pages ) {
 		$query_args['prs_added_pages'] = $pages;
+	}
+
+	if ( $attachment_id ) {
+		$query_args['prs_added_cover'] = (int) $attachment_id;
 	}
 
 	$url = add_query_arg( $query_args, $redirect_url );


### PR DESCRIPTION
## Summary
- show a success state inside the add book modal that replaces the form after a successful submission and lists the submitted details
- persist sanitized book data in the redirect query so it can be displayed in the modal
- add styles and client-side logic to present and dismiss the success state while keeping the form accessible for later use

## Testing
- ./vendor/bin/phpcs --standard=WordPress modules/reading/shortcodes/add-book.php

------
https://chatgpt.com/codex/tasks/task_e_68d034e666dc8332b804cea164f7894a