### PR TITLE
Add mode switch for single and multiple book entry

### DIFF
--- a/modules/chatgpt/modules/shortcode/confirm-table-shortcode.php
+++ b/modules/chatgpt/modules/shortcode/confirm-table-shortcode.php
@@ -136,7 +136,7 @@ function politeia_confirm_table_shortcode() {
 							<th>Title</th>
 							<th>Author</th>
 							<th style="width:120px">Year</th>
-							<th style="width:220px">Action</th>
+                                                        <th style="width:120px">Action</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -202,6 +202,7 @@ function politeia_confirm_table_shortcode() {
                 .pol-btn[disabled]{opacity:.45;cursor:not-allowed}
                 .pol-btn-primary{background:#1a73e8;color:#fff;border-color:#1a73e8}
                 .pol-btn-ghost{background:#eaf2fe;border-color:#1b73e8;color:#1b73e8;border:none}
+                .pol-actions{width:120px}
                 .pol-btn-ghost:hover{background:#1b73e8;color:#fff}
                 .pol-edit{margin-left:8px;font-size:12px;line-height:1;border:0;background:#f0f0f0;border-radius:8px;padding:4px 6px;cursor:pointer;color:#1b73e8}
                 .pol-edit:hover{background:#1b73e8;color:#fff}

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -223,6 +223,10 @@
         box-shadow: 0 18px 45px rgba(17, 24, 39, 0.25);
 }
 
+.prs-add-book__modal-content--multiple {
+        max-width: 820px;
+}
+
 .prs-add-book__modal-content--success {
         display: flex;
         flex-direction: column;

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -316,20 +316,51 @@
         gap: 12px;
 }
 
-.prs-add-book__mode-switch a {
+.prs-add-book__mode-switch a,
+.prs-add-book__mode-button {
         color: #0d6efd;
         text-decoration: none;
         font-weight: 600;
 }
 
+.prs-add-book__mode-button {
+        background: none;
+        border: 0;
+        padding: 0;
+        cursor: pointer;
+        font: inherit;
+}
+
 .prs-add-book__mode-switch a:hover,
-.prs-add-book__mode-switch a:focus {
+.prs-add-book__mode-switch a:focus,
+.prs-add-book__mode-button:hover,
+.prs-add-book__mode-button:focus {
         text-decoration: underline;
+}
+
+.prs-add-book__mode-button.is-active {
+        color: #1f2937;
+        cursor: default;
+        text-decoration: none;
+}
+
+.prs-add-book__mode-button.is-active:hover,
+.prs-add-book__mode-button.is-active:focus {
+        text-decoration: none;
 }
 
 .prs-add-book__mode-separator {
         color: #9ca3af;
         font-weight: 500;
+}
+
+.prs-add-book__multiple {
+        margin-top: 16px;
+}
+
+.prs-add-book__mode-unavailable {
+        margin: 0;
+        text-align: center;
 }
 
 .prs-add-book__close {

--- a/modules/reading/assets/js/add-book.js
+++ b/modules/reading/assets/js/add-book.js
@@ -6,7 +6,12 @@
         var successContainer = document.getElementById('prs-add-book-success');
         var successHeading = successContainer ? successContainer.querySelector('.prs-add-book__success-heading') : null;
         var closeButton = modal ? modal.querySelector('.prs-add-book__close') : null;
+        var modeSwitch = document.getElementById('prs-add-book-mode-switch');
+        var modeButtons = modeSwitch ? modeSwitch.querySelectorAll('.prs-add-book__mode-button') : null;
+        var multipleContainer = document.getElementById('prs-add-book-multiple');
+        var multipleHeading = multipleContainer ? multipleContainer.querySelector('.prs-add-book__heading') : null;
         var successActive = false;
+        var currentMode = 'single';
 
         var updateAriaLabelledBy = function (id) {
                 if (!modal) {
@@ -45,6 +50,114 @@
                 }
         };
 
+        var updateModeButtons = function () {
+                if (!modeButtons || !modeButtons.length) {
+                        return;
+                }
+
+                for (var i = 0; i < modeButtons.length; i++) {
+                        var button = modeButtons[i];
+                        var buttonMode = button.getAttribute('data-mode') || 'single';
+                        if (buttonMode === currentMode) {
+                                button.classList.add('is-active');
+                                button.setAttribute('aria-pressed', 'true');
+                        } else {
+                                button.classList.remove('is-active');
+                                button.setAttribute('aria-pressed', 'false');
+                        }
+                }
+        };
+
+        var updateModeVisibility = function () {
+                var pendingSuccess = successActive || (modal && modal.getAttribute('data-success') === '1');
+
+                if (modeSwitch) {
+                        modeSwitch.hidden = pendingSuccess;
+                }
+
+                if (pendingSuccess) {
+                        if (form) {
+                                form.hidden = true;
+                        }
+                        if (formHeading) {
+                                formHeading.hidden = true;
+                        }
+                        if (multipleContainer) {
+                                multipleContainer.hidden = true;
+                        }
+                        if (multipleHeading) {
+                                multipleHeading.hidden = true;
+                        }
+                        return;
+                }
+
+                if (currentMode === 'multiple' && multipleContainer) {
+                        if (form) {
+                                form.hidden = true;
+                        }
+                        if (formHeading) {
+                                formHeading.hidden = true;
+                        }
+                        multipleContainer.hidden = false;
+                        if (multipleHeading) {
+                                multipleHeading.hidden = false;
+                                if (multipleHeading.id) {
+                                        updateAriaLabelledBy(multipleHeading.id);
+                                }
+                        }
+                } else {
+                        currentMode = 'single';
+                        if (form) {
+                                form.hidden = false;
+                        }
+                        if (formHeading) {
+                                formHeading.hidden = false;
+                                if (formHeading.id) {
+                                        updateAriaLabelledBy(formHeading.id);
+                                }
+                        }
+                        if (multipleContainer) {
+                                multipleContainer.hidden = true;
+                        }
+                        if (multipleHeading) {
+                                multipleHeading.hidden = true;
+                        }
+                }
+        };
+
+        var setMode = function (mode) {
+                if (mode === 'multiple' && !multipleContainer) {
+                        mode = 'single';
+                } else if (mode !== 'multiple') {
+                        mode = 'single';
+                }
+
+                if (mode === currentMode) {
+                        updateModeButtons();
+                        updateModeVisibility();
+                        return;
+                }
+
+                currentMode = mode;
+                updateModeButtons();
+                updateModeVisibility();
+        };
+
+        if (modeButtons && modeButtons.length) {
+                for (var j = 0; j < modeButtons.length; j++) {
+                        modeButtons[j].addEventListener('click', function (event) {
+                                if (event && typeof event.preventDefault === 'function') {
+                                        event.preventDefault();
+                                }
+                                var buttonMode = event && event.currentTarget ? event.currentTarget.getAttribute('data-mode') : null;
+                                setMode(buttonMode);
+                        });
+                }
+        }
+
+        updateModeButtons();
+        updateModeVisibility();
+
         var resetToForm = function (force) {
                 if (!successActive && !force) {
                         return;
@@ -60,14 +173,7 @@
                         modalContent.classList.remove('prs-add-book__modal-content--success');
                 }
 
-                if (form) {
-                        form.hidden = false;
-                }
-
-                if (formHeading) {
-                        formHeading.hidden = false;
-                        updateAriaLabelledBy(formHeading.id);
-                }
+                setMode('single');
         };
 
         var activateSuccess = function () {
@@ -86,13 +192,7 @@
                         modalContent.classList.add('prs-add-book__modal-content--success');
                 }
 
-                if (form) {
-                        form.hidden = true;
-                }
-
-                if (formHeading) {
-                        formHeading.hidden = true;
-                }
+                setMode('single');
 
                 if (successHeading && successHeading.id) {
                         updateAriaLabelledBy(successHeading.id);

--- a/modules/reading/assets/js/add-book.js
+++ b/modules/reading/assets/js/add-book.js
@@ -71,6 +71,14 @@
         var updateModeVisibility = function () {
                 var pendingSuccess = successActive || (modal && modal.getAttribute('data-success') === '1');
 
+                if (modalContent) {
+                        if (pendingSuccess) {
+                                modalContent.classList.remove('prs-add-book__modal-content--multiple');
+                        } else {
+                                modalContent.classList.toggle('prs-add-book__modal-content--multiple', currentMode === 'multiple');
+                        }
+                }
+
                 if (modeSwitch) {
                         modeSwitch.hidden = pendingSuccess;
                 }

--- a/modules/reading/shortcodes/add-book.php
+++ b/modules/reading/shortcodes/add-book.php
@@ -12,14 +12,20 @@ add_shortcode(
 		}
 
 		wp_enqueue_style( 'politeia-reading' );
-		wp_enqueue_script( 'politeia-add-book' );
+                wp_enqueue_script( 'politeia-add-book' );
 
-		$success           = ! empty( $_GET['prs_added'] ) && '1' === $_GET['prs_added'];
-		$success_title     = '';
-		$success_author    = '';
-		$success_year      = null;
-		$success_pages     = null;
-		$success_cover_url = '';
+                $success                = ! empty( $_GET['prs_added'] ) && '1' === $_GET['prs_added'];
+                $success_title          = '';
+                $success_author         = '';
+                $success_year           = null;
+                $success_pages          = null;
+                $success_cover_url      = '';
+                $multiple_mode_content  = '';
+                $multiple_shortcode_tag = 'politeia_chatgpt_input';
+
+                if ( shortcode_exists( $multiple_shortcode_tag ) ) {
+                        $multiple_mode_content = do_shortcode( '[' . $multiple_shortcode_tag . ']' );
+                }
 
 		if ( $success ) {
 			if ( isset( $_GET['prs_added_title'] ) ) {
@@ -83,8 +89,8 @@ add_shortcode(
 					onclick="document.getElementById('prs-add-book-modal').style.display='none'">
 					&times;
 				</button>
-				<div id="prs-add-book-success" class="prs-add-book__success"<?php echo $success ? '' : ' hidden'; ?>>
-					<?php if ( $success_cover_url ) : ?>
+                                <div id="prs-add-book-success" class="prs-add-book__success"<?php echo $success ? '' : ' hidden'; ?>>
+                                        <?php if ( $success_cover_url ) : ?>
 						<?php
 						$success_cover_alt = $success_title
 							? sprintf(
@@ -131,25 +137,31 @@ add_shortcode(
 						<?php endif; ?>
 					</ul>
 				</div>
-				<form id="prs-add-book-form"
-					class="prs-form"
-					method="post"
-					enctype="multipart/form-data"
-					action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>"<?php echo $success ? ' hidden' : ''; ?>>
-					<h2 id="prs-add-book-form-title" class="prs-add-book__heading"<?php echo $success ? ' hidden' : ''; ?>>
-						<?php echo esc_html__( 'Add to Library', 'politeia-reading' ); ?>
-					</h2>
-					<div id="prs-add-book-mode-switch" class="prs-add-book__mode-switch">
-						<a href="#" onclick="return false;">
-							<?php esc_html_e( 'Single', 'politeia-reading' ); ?>
-						</a>
-						<span class="prs-add-book__mode-separator" aria-hidden="true">|</span>
-						<a href="#" onclick="return false;">
-							<?php esc_html_e( 'Multiple', 'politeia-reading' ); ?>
-						</a>
-					</div>
-					<?php wp_nonce_field( 'prs_add_book', 'prs_nonce' ); ?>
-					<input type="hidden" name="action" value="prs_add_book_submit" />
+                                <div id="prs-add-book-mode-switch" class="prs-add-book__mode-switch"<?php echo $success ? ' hidden' : ''; ?>>
+                                        <button type="button"
+                                                class="prs-add-book__mode-button is-active"
+                                                data-mode="single"
+                                                aria-pressed="true">
+                                                <?php esc_html_e( 'Single', 'politeia-reading' ); ?>
+                                        </button>
+                                        <span class="prs-add-book__mode-separator" aria-hidden="true">|</span>
+                                        <button type="button"
+                                                class="prs-add-book__mode-button"
+                                                data-mode="multiple"
+                                                aria-pressed="false">
+                                                <?php esc_html_e( 'Multiple', 'politeia-reading' ); ?>
+                                        </button>
+                                </div>
+                                <form id="prs-add-book-form"
+                                        class="prs-form"
+                                        method="post"
+                                        enctype="multipart/form-data"
+                                        action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>"<?php echo $success ? ' hidden' : ''; ?>>
+                                        <h2 id="prs-add-book-form-title" class="prs-add-book__heading"<?php echo $success ? ' hidden' : ''; ?>>
+                                                <?php echo esc_html__( 'Add to Library', 'politeia-reading' ); ?>
+                                        </h2>
+                                        <?php wp_nonce_field( 'prs_add_book', 'prs_nonce' ); ?>
+                                        <input type="hidden" name="action" value="prs_add_book_submit" />
 
 					<table class="prs-form__table">
 						<tbody>
@@ -257,11 +269,23 @@ add_shortcode(
 									<button class="prs-btn" type="submit"><?php esc_html_e( 'Save to My Library', 'politeia-reading' ); ?></button>
 								</td>
 							</tr>
-						</tbody>
-						</table>
-						</form>
-						<script>
-							( function () {
+                                                </tbody>
+                                                </table>
+                                                </form>
+                                                <div id="prs-add-book-multiple" class="prs-add-book__multiple" hidden>
+                                                        <h2 id="prs-add-book-multiple-title" class="prs-add-book__heading">
+                                                                <?php echo esc_html__( 'Add Multiple Books', 'politeia-reading' ); ?>
+                                                        </h2>
+                                                        <?php if ( $multiple_mode_content ) : ?>
+                                                                <?php echo $multiple_mode_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                                        <?php else : ?>
+                                                                <p class="prs-add-book__mode-unavailable">
+                                                                        <?php echo esc_html__( 'The multiple entry mode is currently unavailable.', 'politeia-reading' ); ?>
+                                                                </p>
+                                                        <?php endif; ?>
+                                                </div>
+                                                <script>
+                                                        ( function () {
 								var fileInput = document.getElementById('prs_cover');
 								if (!fileInput) {
 									return;


### PR DESCRIPTION
## Summary
- render a mode switch in the add-book modal that can show the existing form or the multiple entry shortcode
- add styles for the new switch buttons and multiple-entry container
- extend the add-book script to toggle between single and multiple modes while respecting the success state

## Testing
- php -l modules/reading/shortcodes/add-book.php

------
https://chatgpt.com/codex/tasks/task_e_68d048073dd883328cf57bc422211a22