### PR TITLE
Add add-book button to My Library header

### DIFF
--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -26,6 +26,24 @@
         border-bottom: none;
 }
 
+#prs-library .prs-library__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+}
+
+#prs-library .prs-library__header-title {
+        font-size: 22px;
+        line-height: 1.3;
+}
+
+#prs-library .prs-library__header-actions {
+        display: flex;
+        align-items: center;
+}
+
 #prs-library tbody tr {
         align-items: stretch;
         border-bottom: 1px solid #eee;

--- a/modules/reading/shortcodes/my-books.php
+++ b/modules/reading/shortcodes/my-books.php
@@ -105,12 +105,26 @@ add_shortcode(
 			)
 		);
 
+		$add_book_shortcode = '';
+		if ( shortcode_exists( 'politeia_add_book' ) ) {
+			$add_book_shortcode = do_shortcode( '[politeia_add_book]' );
+		}
+
 		ob_start(); ?>
         <div class="prs-library">
                <table id="prs-library" class="prs-table">
                <thead>
                         <tr>
-                        <th scope="colgroup" colspan="2"><?php esc_html_e( 'My Library', 'politeia-reading' ); ?></th>
+                        <th scope="colgroup" colspan="2">
+                                <div class="prs-library__header">
+                                        <span class="prs-library__header-title"><?php esc_html_e( 'My Library', 'politeia-reading' ); ?></span>
+                                        <?php if ( $add_book_shortcode ) : ?>
+                                                <div class="prs-library__header-actions">
+                                                        <?php echo $add_book_shortcode; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                                </div>
+                                        <?php endif; ?>
+                                </div>
+                        </th>
                         </tr>
                </thead>
                 <tbody>


### PR DESCRIPTION
## Summary
- show the add book shortcode beside the My Library heading
- style the table header so the heading is 22px and aligns with the button

## Testing
- php -l modules/reading/shortcodes/my-books.php

------
https://chatgpt.com/codex/tasks/task_e_68d07135509483329a428dc2450faf9a