### PR TITLE
Add type column to user books schema

### DIFF
--- a/modules/reading/includes/class-activator.php
+++ b/modules/reading/includes/class-activator.php
@@ -78,6 +78,7 @@ class Politeia_Reading_Activator {
             rating TINYINT UNSIGNED NULL DEFAULT NULL,
             reading_status ENUM('not_started','started','finished') NOT NULL DEFAULT 'not_started',
             owning_status  ENUM('in_shelf','lost','borrowed','borrowing','sold') NOT NULL DEFAULT 'in_shelf',
+            type_book ENUM('p','d') NULL DEFAULT NULL,
             pages INT UNSIGNED NULL,
             purchase_date DATE NULL,
             purchase_channel ENUM('online','store') NULL,

--- a/modules/reading/includes/helpers.php
+++ b/modules/reading/includes/helpers.php
@@ -156,10 +156,18 @@ function prs_maybe_alter_user_books() {
 	);
 	$has  = array_map( 'strtolower', (array) $cols );
 
-	$alters = array();
-	if ( ! in_array( 'pages', $has, true ) ) {
-		$alters[] = 'ADD COLUMN pages INT UNSIGNED NULL AFTER owning_status';
-	}
+        $alters = array();
+
+        $has_type_book = in_array( 'type_book', $has, true );
+        if ( ! $has_type_book ) {
+                $alters[]     = "ADD COLUMN type_book ENUM('p','d') NULL DEFAULT NULL AFTER owning_status";
+                $has_type_book = true;
+        }
+
+        if ( ! in_array( 'pages', $has, true ) ) {
+                $after_column = $has_type_book ? 'type_book' : 'owning_status';
+                $alters[]     = sprintf( 'ADD COLUMN pages INT UNSIGNED NULL AFTER %s', $after_column );
+        }
 	if ( ! in_array( 'purchase_date', $has, true ) ) {
 		$alters[] = 'ADD COLUMN purchase_date DATE NULL';
 	}


### PR DESCRIPTION
## Summary
- add a `type_book` column to the user books table schema to store format flags
- update the migration helper to add the new column and keep pages positioning consistent

## Testing
- composer validate


------
https://chatgpt.com/codex/tasks/task_e_68d6d6c6c6608332ad647483dd0faa05