### PR TITLE
Add book format selector alongside user rating

### DIFF
--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -859,7 +859,7 @@ span#purchase-channel-form {
 /* Container */
 .prs-stars {
         display: inline-flex;
-        gap: 4px;
+        gap: 2px;
         user-select: none;
         -webkit-tap-highlight-color: transparent; /* mobile: no blue flash */
 }
@@ -868,14 +868,15 @@ span#purchase-channel-form {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
-        gap: 12px;
 }
 
 .prs-field--rating-type .prs-rating-block {
         display: flex;
         align-items: center;
         gap: 8px;
-        flex: 1 1 220px;
+        flex: 1 1 50%;
+        max-width: 50%;
+        min-width: 0;
 }
 
 .prs-field--rating-type .prs-type-book {
@@ -883,7 +884,9 @@ span#purchase-channel-form {
         align-items: center;
         justify-content: flex-end;
         gap: 8px;
-        flex: 1 1 200px;
+        flex: 1 1 50%;
+        max-width: 50%;
+        min-width: 0;
 }
 
 .prs-field--rating-type .prs-type-book__label {
@@ -903,6 +906,13 @@ span#purchase-channel-form {
         .prs-field--rating-type .prs-type-book {
                 justify-content: flex-start;
                 width: 100%;
+                max-width: 100%;
+                flex-basis: 100%;
+        }
+
+        .prs-field--rating-type .prs-rating-block {
+                max-width: 100%;
+                flex-basis: 100%;
         }
 }
 
@@ -910,8 +920,8 @@ span#purchase-channel-form {
 .prs-star {
         all: unset;                 /* wipe default <button> styles */
         display: inline-block;
-	padding: 0 2px;
-	font-size: 22px;
+        padding: 0;
+        font-size: 14px;
 	line-height: 1;
 	color: #bbb;                /* inactive */
 	cursor: pointer;

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -858,16 +858,58 @@ span#purchase-channel-form {
 
 /* Container */
 .prs-stars {
-	display: inline-flex;
-	gap: 4px;
-	user-select: none;
-	-webkit-tap-highlight-color: transparent; /* mobile: no blue flash */
+        display: inline-flex;
+        gap: 4px;
+        user-select: none;
+        -webkit-tap-highlight-color: transparent; /* mobile: no blue flash */
+}
+
+.prs-field--rating-type {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 12px;
+}
+
+.prs-field--rating-type .prs-rating-block {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex: 1 1 220px;
+}
+
+.prs-field--rating-type .prs-type-book {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 8px;
+        flex: 1 1 200px;
+}
+
+.prs-field--rating-type .prs-type-book__label {
+        font-weight: 600;
+}
+
+.prs-field--rating-type .prs-type-book__select {
+        min-width: 150px;
+}
+
+@media (max-width: 600px) {
+        .prs-field--rating-type {
+                flex-direction: column;
+                align-items: flex-start;
+        }
+
+        .prs-field--rating-type .prs-type-book {
+                justify-content: flex-start;
+                width: 100%;
+        }
 }
 
 /* Full reset so no theme/UA button styles sneak in */
 .prs-star {
-	all: unset;                 /* wipe default <button> styles */
-	display: inline-block;
+        all: unset;                 /* wipe default <button> styles */
+        display: inline-block;
 	padding: 0 2px;
 	font-size: 22px;
 	line-height: 1;

--- a/modules/reading/assets/js/my-book.js
+++ b/modules/reading/assets/js/my-book.js
@@ -388,6 +388,36 @@
     });
   }
 
+  // ---------- Type of book ----------
+  function setupTypeBook() {
+    const wrap = qs("#fld-user-rating");
+    if (!wrap || !window.PRS_BOOK) return;
+
+    const select = qs("#prs-type-book", wrap);
+    const status = qs("#type-book-status", wrap);
+
+    if (!select) return;
+
+    select.addEventListener("change", () => {
+      const val = (select.value || "").trim();
+      const fd = new FormData();
+      fd.append("action", "prs_update_user_book_meta");
+      fd.append("nonce", PRS_BOOK.nonce);
+      fd.append("user_book_id", String(PRS_BOOK.user_book_id));
+      fd.append("type_book", val);
+
+      ajaxPost(PRS_BOOK.ajax_url, fd)
+        .then(json => {
+          if (!json || !json.success) throw json;
+          setStatus(status, "Saved.", true);
+        })
+        .catch(err => {
+          const msg = (err && err.data && err.data.message) ? err.data.message : "Error saving format.";
+          setStatus(status, msg, false, 4000);
+        });
+    });
+  }
+
   // ---------- Reading Status ----------
   function setupReadingStatus() {
     const wrap = qs("#fld-reading-status");
@@ -605,6 +635,7 @@
     setupPurchaseDate();
     setupPurchaseChannel();
     setupRating();
+    setupTypeBook();
     setupReadingStatus();
     setupOwningStatus();
     setupSessionsAjax();

--- a/modules/reading/includes/class-user-books.php
+++ b/modules/reading/includes/class-user-books.php
@@ -137,18 +137,28 @@ class Politeia_Reading_User_Books {
 			$d                       = sanitize_text_field( wp_unslash( $_POST['purchase_date'] ) );
 			$update['purchase_date'] = ( $d && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $d ) ) ? $d : null;
 		}
-		if ( array_key_exists( 'purchase_channel', $_POST ) ) {
-			$pc                         = sanitize_key( $_POST['purchase_channel'] );
-			$update['purchase_channel'] = in_array( $pc, array( 'online', 'store' ), true ) ? $pc : null;
-		}
-		if ( array_key_exists( 'purchase_place', $_POST ) ) {
-			$update['purchase_place'] = sanitize_text_field( wp_unslash( $_POST['purchase_place'] ) );
-		}
-		if ( array_key_exists( 'reading_status', $_POST ) ) {
-			$rs = sanitize_key( wp_unslash( $_POST['reading_status'] ) );
-			if ( in_array( $rs, self::allowed_reading_status(), true ) ) {
-				$update['reading_status'] = $rs;
-			}
+                if ( array_key_exists( 'purchase_channel', $_POST ) ) {
+                        $pc                         = sanitize_key( $_POST['purchase_channel'] );
+                        $update['purchase_channel'] = in_array( $pc, array( 'online', 'store' ), true ) ? $pc : null;
+                }
+                if ( array_key_exists( 'purchase_place', $_POST ) ) {
+                        $update['purchase_place'] = sanitize_text_field( wp_unslash( $_POST['purchase_place'] ) );
+                }
+                if ( array_key_exists( 'type_book', $_POST ) ) {
+                        $raw = wp_unslash( $_POST['type_book'] );
+                        $tb  = sanitize_key( $raw );
+
+                        if ( in_array( $tb, array( 'p', 'd' ), true ) ) {
+                                $update['type_book'] = $tb;
+                        } elseif ( '' === $raw || null === $raw ) {
+                                $update['type_book'] = null;
+                        }
+                }
+                if ( array_key_exists( 'reading_status', $_POST ) ) {
+                        $rs = sanitize_key( wp_unslash( $_POST['reading_status'] ) );
+                        if ( in_array( $rs, self::allowed_reading_status(), true ) ) {
+                                $update['reading_status'] = $rs;
+                        }
 		}
 
 		// ====== RATING ======

--- a/modules/reading/templates/my-book-single.php
+++ b/modules/reading/templates/my-book-single.php
@@ -169,21 +169,35 @@ wp_localize_script(
 		<?php echo $book->year ? ' · ' . (int) $book->year : ''; ?>
 		</div>
 
-		<?php $current_rating = isset( $ub->rating ) && $ub->rating !== null ? (int) $ub->rating : 0; ?>
-		<div class="prs-field" id="fld-user-rating">
-		<div id="prs-user-rating" class="prs-stars" role="radiogroup" aria-label="<?php esc_attr_e( 'Your rating', 'politeia-reading' ); ?>">
-			<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
-			<button type="button"
-				class="prs-star<?php echo ( $i <= $current_rating ) ? ' is-active' : ''; ?>"
-				data-value="<?php echo $i; ?>"
-				role="radio"
-				aria-checked="<?php echo ( $i === $current_rating ) ? 'true' : 'false'; ?>">
-				★
-			</button>
-			<?php endfor; ?>
-		</div>
-		<span id="rating-status" class="prs-help" style="margin-left:8px;"></span>
-		</div>
+                <?php
+                $current_rating = isset( $ub->rating ) && null !== $ub->rating ? (int) $ub->rating : 0;
+                $current_type   = ( isset( $ub->type_book ) && in_array( $ub->type_book, array( 'p', 'd' ), true ) ) ? $ub->type_book : '';
+                ?>
+                <div class="prs-field prs-field--rating-type" id="fld-user-rating">
+                        <div class="prs-rating-block">
+                                <div id="prs-user-rating" class="prs-stars" role="radiogroup" aria-label="<?php esc_attr_e( 'Your rating', 'politeia-reading' ); ?>">
+                                        <?php for ( $i = 1; $i <= 5; $i++ ) : ?>
+                                                <button type="button"
+                                                        class="prs-star<?php echo ( $i <= $current_rating ) ? ' is-active' : ''; ?>"
+                                                        data-value="<?php echo $i; ?>"
+                                                        role="radio"
+                                                        aria-checked="<?php echo ( $i === $current_rating ) ? 'true' : 'false'; ?>">
+                                                        ★
+                                                </button>
+                                        <?php endfor; ?>
+                                </div>
+                                <span id="rating-status" class="prs-help" aria-live="polite"></span>
+                        </div>
+                        <div class="prs-type-book">
+                                <label for="prs-type-book" class="prs-type-book__label"><?php esc_html_e( 'Format', 'politeia-reading' ); ?></label>
+                                <select id="prs-type-book" class="prs-type-book__select">
+                                        <option value="" <?php selected( $current_type, '' ); ?>><?php esc_html_e( 'Not specified', 'politeia-reading' ); ?></option>
+                                        <option value="d" <?php selected( $current_type, 'd' ); ?>><?php esc_html_e( 'Digital', 'politeia-reading' ); ?></option>
+                                        <option value="p" <?php selected( $current_type, 'p' ); ?>><?php esc_html_e( 'Printed', 'politeia-reading' ); ?></option>
+                                </select>
+                                <span id="type-book-status" class="prs-help" aria-live="polite"></span>
+                        </div>
+                </div>
 
 		<!-- Pages -->
 		<div class="prs-field" id="fld-pages">


### PR DESCRIPTION
## Summary
- add a book format dropdown next to the user rating controls
- persist the selected format through the existing AJAX endpoint into `type_book`
- style the rating/format row so the two controls share the space responsively

## Testing
- composer validate
- php -l modules/reading/templates/my-book-single.php
- php -l modules/reading/includes/class-user-books.php

------
https://chatgpt.com/codex/tasks/task_e_68d6de2ef9888332a02209048ea8a493