### PR TITLE
Adjust session recorder height to fit content

### DIFF
--- a/modules/reading/templates/my-book-single.php
+++ b/modules/reading/templates/my-book-single.php
@@ -81,8 +81,8 @@ wp_localize_script(
 	.prs-box{ background:#f9f9f9; padding:16px; min-height:120px; }
 	#prs-book-cover{ grid-column:1; grid-row:1 / span 2; }
 	#prs-book-info{ grid-column:2; grid-row:1; min-height:140px; }
-	#prs-session-recorder{ grid-column:3; grid-row:1; min-height:auto; background:#ffffff;
-	padding: 16px; border: 1px solid #dddddd; }
+        #prs-session-recorder{ grid-column:3; grid-row:1; min-height:auto; background:#ffffff;
+        padding: 16px; border: 1px solid #dddddd; align-self:start; }
 	#prs-reading-sessions{ grid-column:1 / 4; grid-row:3; min-height:320px; }
 
 	/* Frame portada */

--- a/modules/reading/templates/my-book-single.php
+++ b/modules/reading/templates/my-book-single.php
@@ -129,7 +129,7 @@ wp_localize_script(
 </style>
 
 <div class="wrap">
-	<p><a href="<?php echo esc_url( home_url( '/my-books' ) ); ?>">&larr; Back to My Books</a></p>
+        <p style="margin-top:10px; font-size:14px;"><a href="<?php echo esc_url( home_url( '/my-books' ) ); ?>">&larr; Back to My Books</a></p>
 
 	<div class="prs-single-grid">
 

--- a/modules/reading/templates/my-book-single.php
+++ b/modules/reading/templates/my-book-single.php
@@ -81,7 +81,7 @@ wp_localize_script(
 	.prs-box{ background:#f9f9f9; padding:16px; min-height:120px; }
 	#prs-book-cover{ grid-column:1; grid-row:1 / span 2; }
 	#prs-book-info{ grid-column:2; grid-row:1; min-height:140px; }
-	#prs-session-recorder{ grid-column:3; grid-row:1; min-height:140px; background:#ffffff;
+	#prs-session-recorder{ grid-column:3; grid-row:1; min-height:auto; background:#ffffff;
 	padding: 16px; border: 1px solid #dddddd; }
 	#prs-reading-sessions{ grid-column:1 / 4; grid-row:3; min-height:320px; }
 


### PR DESCRIPTION
## Summary
- allow the session recorder panel to size itself based on its content instead of matching the book info section

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d726c02f488332bb084a3e22a93d9f