### PR TITLE
Add author tables and sync helpers for multi-author support

### DIFF
--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -401,13 +401,56 @@
 .prs-add-book__authors {
         display: flex;
         flex-direction: column;
-        gap: 10px;
+        gap: 8px;
 }
 
-.prs-add-book__author {
+.prs-add-book__author-list {
         display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 0;
+        padding: 0;
+}
+
+.prs-add-book__author-chip {
+        display: inline-flex;
         align-items: center;
-        gap: 12px;
+        gap: 6px;
+        background-color: #f3f4f6;
+        border: 1px solid #e5e7eb;
+        color: #1f2937;
+        border-radius: 9999px;
+        font-size: 0.9rem;
+        font-weight: 500;
+        padding: 4px 10px;
+}
+
+.prs-add-book__author-chip-label {
+        line-height: 1.2;
+        white-space: nowrap;
+}
+
+.prs-add-book__author-chip-remove {
+        background: transparent;
+        border: 0;
+        color: #6b7280;
+        cursor: pointer;
+        font-size: 1rem;
+        line-height: 1;
+        padding: 2px 4px;
+        border-radius: 50%;
+        transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.prs-add-book__author-chip-remove:hover,
+.prs-add-book__author-chip-remove:focus {
+        color: #dc2626;
+        background-color: rgba(220, 38, 38, 0.12);
+        outline: none;
+}
+
+.prs-add-book__author-input-wrapper {
+        display: flex;
 }
 
 .prs-add-book__author-input {
@@ -415,45 +458,14 @@
         min-width: 0;
 }
 
-.prs-add-book__remove-author {
-        background: none;
-        border: 0;
-        color: #dc2626;
-        cursor: pointer;
+.prs-add-book__author-hidden {
+        display: none;
+}
+
+.prs-add-book__author-hint {
+        color: #6b7280;
         font-size: 0.85rem;
-        font-weight: 600;
-        padding: 4px 8px;
-        border-radius: 6px;
-        transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.prs-add-book__remove-author:hover,
-.prs-add-book__remove-author:focus {
-        background-color: rgba(220, 38, 38, 0.08);
-        color: #b91c1c;
-        outline: none;
-}
-
-.prs-add-book__add-author {
-        margin-top: 12px;
-        background: none;
-        border: 0;
-        color: #0d6efd;
-        cursor: pointer;
-        font-size: 0.95rem;
-        font-weight: 600;
-        padding: 0;
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        transition: color 0.2s ease;
-}
-
-.prs-add-book__add-author:hover,
-.prs-add-book__add-author:focus {
-        color: #0a58ca;
-        text-decoration: underline;
-        outline: none;
+        margin: 0;
 }
 
 .prs-add-book__multiple {

--- a/modules/reading/assets/css/politeia.css
+++ b/modules/reading/assets/css/politeia.css
@@ -394,6 +394,68 @@
         font-weight: 500;
 }
 
+.prs-add-book__modal-content--success #prs-add-book-mode-switch {
+        display: none;
+}
+
+.prs-add-book__authors {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+}
+
+.prs-add-book__author {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+}
+
+.prs-add-book__author-input {
+        flex: 1 1 auto;
+        min-width: 0;
+}
+
+.prs-add-book__remove-author {
+        background: none;
+        border: 0;
+        color: #dc2626;
+        cursor: pointer;
+        font-size: 0.85rem;
+        font-weight: 600;
+        padding: 4px 8px;
+        border-radius: 6px;
+        transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.prs-add-book__remove-author:hover,
+.prs-add-book__remove-author:focus {
+        background-color: rgba(220, 38, 38, 0.08);
+        color: #b91c1c;
+        outline: none;
+}
+
+.prs-add-book__add-author {
+        margin-top: 12px;
+        background: none;
+        border: 0;
+        color: #0d6efd;
+        cursor: pointer;
+        font-size: 0.95rem;
+        font-weight: 600;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        transition: color 0.2s ease;
+}
+
+.prs-add-book__add-author:hover,
+.prs-add-book__add-author:focus {
+        color: #0a58ca;
+        text-decoration: underline;
+        outline: none;
+}
+
 .prs-add-book__multiple {
         margin-top: 16px;
 }

--- a/modules/reading/includes/class-activator.php
+++ b/modules/reading/includes/class-activator.php
@@ -43,10 +43,12 @@ class Politeia_Reading_Activator {
 
 		$charset_collate = $wpdb->get_charset_collate();
 
-		$books_table      = $wpdb->prefix . 'politeia_books';
-		$user_books_table = $wpdb->prefix . 'politeia_user_books';
-		$sessions_table   = $wpdb->prefix . 'politeia_reading_sessions';
-		$loans_table      = $wpdb->prefix . 'politeia_loans';
+		$books_table         = $wpdb->prefix . 'politeia_books';
+		$user_books_table    = $wpdb->prefix . 'politeia_user_books';
+		$sessions_table      = $wpdb->prefix . 'politeia_reading_sessions';
+		$loans_table         = $wpdb->prefix . 'politeia_loans';
+		$authors_table       = $wpdb->prefix . 'politeia_authors';
+		$book_authors_table  = $wpdb->prefix . 'politeia_book_authors';
 
 		// 1) Canonical books table (con hash único)
 		$sql_books = "CREATE TABLE {$books_table} (
@@ -129,10 +131,38 @@ class Politeia_Reading_Activator {
             KEY idx_book (book_id)
         ) {$charset_collate};";
 
+		$sql_authors = "CREATE TABLE {$authors_table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            display_name VARCHAR(255) NOT NULL,
+            normalized_name VARCHAR(255) NULL,
+            name_hash CHAR(64) NOT NULL,
+            slug VARCHAR(255) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            UNIQUE KEY uniq_name_hash (name_hash),
+            UNIQUE KEY uniq_slug (slug)
+        ) {$charset_collate};";
+
+		$sql_book_authors = "CREATE TABLE {$book_authors_table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            book_id BIGINT UNSIGNED NOT NULL,
+            author_id BIGINT UNSIGNED NOT NULL,
+            sort_order SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            UNIQUE KEY uniq_book_author (book_id, author_id),
+            KEY idx_book (book_id),
+            KEY idx_author (author_id)
+        ) {$charset_collate};";
+
 		dbDelta( $sql_books );
 		dbDelta( $sql_user_books );
 		dbDelta( $sql_sessions );
 		dbDelta( $sql_loans );
+		dbDelta( $sql_authors );
+		dbDelta( $sql_book_authors );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- bump the Politeia Reading version to 0.2.3 and add an admin notice that flags missing core tables
- extend the activator to create author and book-author mapping tables during activation or upgrades
- update helper routines to sync book-author links so multi-author metadata is persisted when books are created or reused

## Testing
- php -l modules/reading/includes/class-activator.php
- php -l modules/reading/includes/helpers.php
- php -l modules/reading/politeia-reading.php

------
https://chatgpt.com/codex/tasks/task_e_68d7fed143bc8332a26ee33cbc1ee4dd